### PR TITLE
feat: return restart count and failure reason

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/model/PodInfo.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/model/PodInfo.java
@@ -12,4 +12,8 @@ import java.time.Instant;
 public class PodInfo {
     private String name;
     private Instant createdAt;
+    private int restartCount;
+    private String lastTerminationReason;
+    private Integer lastExitCode;
+    private Integer lastSignal;
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -22,6 +22,7 @@ import com.epam.aidial.deployment.manager.model.deployment.Deployment;
 import com.epam.aidial.deployment.manager.service.manifest.ManifestGenerator;
 import com.epam.aidial.deployment.manager.service.pipeline.specification.CiliumNetworkPolicyCreator;
 import com.epam.aidial.deployment.manager.utils.K8sNamingUtils;
+import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Event;
@@ -431,29 +432,50 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         }
 
         int totalRestartCount = 0;
-        String lastTerminationReason = null;
-        Integer lastExitCode = null;
-        Integer lastSignal = null;
+        ContainerStateTerminated mostRecentTermination = null;
 
         for (var containerStatus : containerStatuses) {
             totalRestartCount += containerStatus.getRestartCount();
 
-            var terminated = getLastTermination(containerStatus);
-            if (terminated != null) {
-                lastTerminationReason = terminated.getReason();
-                lastExitCode = terminated.getExitCode();
-                lastSignal = terminated.getSignal();
-            }
+            // Check both 'state' (current) and 'lastState' (previous)
+            // to find the most recent failure event.
+            var currentTerminated = getTerminatedState(containerStatus.getState());
+            var previousTerminated = getTerminatedState(containerStatus.getLastState());
+
+            // Compare timestamps to find the true "latest" error
+            mostRecentTermination = getLaterTermination(mostRecentTermination, currentTerminated);
+            mostRecentTermination = getLaterTermination(mostRecentTermination, previousTerminated);
         }
 
-        return new ContainerInfo(totalRestartCount, lastTerminationReason, lastExitCode, lastSignal);
+        if (mostRecentTermination != null) {
+            return new ContainerInfo(
+                    totalRestartCount,
+                    mostRecentTermination.getReason(),
+                    mostRecentTermination.getExitCode(),
+                    mostRecentTermination.getSignal()
+            );
+        }
+
+        return new ContainerInfo(totalRestartCount, null, null, null);
     }
 
-    private ContainerStateTerminated getLastTermination(ContainerStatus containerStatus) {
-        if (containerStatus.getLastState() == null) {
-            return null;
+    private ContainerStateTerminated getTerminatedState(ContainerState state) {
+        return (state != null) ? state.getTerminated() : null;
+    }
+
+    private ContainerStateTerminated getLaterTermination(ContainerStateTerminated currentBest,
+                                                         ContainerStateTerminated candidate) {
+        if (candidate == null) {
+            return currentBest;
         }
-        return containerStatus.getLastState().getTerminated();
+        if (currentBest == null) {
+            return candidate;
+        }
+
+        var t1 = Instant.parse(currentBest.getFinishedAt());
+        var t2 = Instant.parse(candidate.getFinishedAt());
+
+        return t2.isAfter(t1) ? candidate : currentBest;
     }
 
     @Override

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -435,7 +435,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         ContainerStateTerminated mostRecentTermination = null;
 
         for (var containerStatus : containerStatuses) {
-            totalRestartCount += containerStatus.getRestartCount();
+            totalRestartCount += containerStatus.getRestartCount() != null ? containerStatus.getRestartCount() : 0;
 
             // Check both 'state' (current) and 'lastState' (previous)
             // to find the most recent failure event.

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -22,6 +22,8 @@ import com.epam.aidial.deployment.manager.model.deployment.Deployment;
 import com.epam.aidial.deployment.manager.service.manifest.ManifestGenerator;
 import com.epam.aidial.deployment.manager.service.pipeline.specification.CiliumNetworkPolicyCreator;
 import com.epam.aidial.deployment.manager.utils.K8sNamingUtils;
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventList;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -31,6 +33,7 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.springframework.transaction.annotation.Isolation;
@@ -402,11 +405,55 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         if (filter != null) {
             podsStream = podsStream.filter(filter);
         }
-        return podsStream.map(pod -> new PodInfo(
-                        pod.getMetadata().getName(),
-                        Instant.parse(pod.getMetadata().getCreationTimestamp())
-                ))
-                .toList();
+        return podsStream.map(this::toPodInfo).toList();
+    }
+
+    private PodInfo toPodInfo(Pod pod) {
+        var containerStatuses = pod.getStatus() != null
+                ? pod.getStatus().getContainerStatuses()
+                : null;
+
+        var containerInfo = extractContainerInfo(containerStatuses);
+
+        return new PodInfo(
+                pod.getMetadata().getName(),
+                Instant.parse(pod.getMetadata().getCreationTimestamp()),
+                containerInfo.restartCount(),
+                containerInfo.lastTerminationReason(),
+                containerInfo.lastExitCode(),
+                containerInfo.lastSignal()
+        );
+    }
+
+    private ContainerInfo extractContainerInfo(List<ContainerStatus> containerStatuses) {
+        if (CollectionUtils.isEmpty(containerStatuses)) {
+            return new ContainerInfo(0, null, null, null);
+        }
+
+        int totalRestartCount = 0;
+        String lastTerminationReason = null;
+        Integer lastExitCode = null;
+        Integer lastSignal = null;
+
+        for (var containerStatus : containerStatuses) {
+            totalRestartCount += containerStatus.getRestartCount();
+
+            var terminated = getLastTermination(containerStatus);
+            if (terminated != null) {
+                lastTerminationReason = terminated.getReason();
+                lastExitCode = terminated.getExitCode();
+                lastSignal = terminated.getSignal();
+            }
+        }
+
+        return new ContainerInfo(totalRestartCount, lastTerminationReason, lastExitCode, lastSignal);
+    }
+
+    private ContainerStateTerminated getLastTermination(ContainerStatus containerStatus) {
+        if (containerStatus.getLastState() == null) {
+            return null;
+        }
+        return containerStatus.getLastState().getTerminated();
     }
 
     @Override
@@ -562,4 +609,13 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                 .map(entry -> Map.entry(entry.getKey(), entry.getValue().getValue()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
+
+    private record ContainerInfo(
+            int restartCount,
+            String lastTerminationReason,
+            Integer lastExitCode,
+            Integer lastSignal
+    ) {
+    }
+
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/web/dto/PodInfoDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/dto/PodInfoDto.java
@@ -6,6 +6,10 @@ import java.time.Instant;
 
 public record PodInfoDto(
         @NotNull String name,
-        @NotNull Instant createdAt
+        @NotNull Instant createdAt,
+        int restartCount,
+        String lastTerminationReason,
+        Integer lastExitCode,
+        Integer lastSignal
 ) {
 }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
@@ -184,6 +184,69 @@ class InferenceDeploymentManagerTest {
     }
 
     @Test
+    void getInstances_shouldReturnPodsWithRestartInfo() {
+        // Given
+        var podList = new PodList();
+        var pod = createPodWithRestartInfo("pod-with-restarts", 5, "OOMKilled", 137, 9);
+        podList.setItems(List.of(pod));
+
+        when(k8sKserveClient.getServicePods(NAMESPACE, GENERATED_SERVICE_NAME)).thenReturn(podList);
+
+        // When
+        var result = inferenceDeploymentManager.getInstances(DEPLOYMENT_ID);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var podInfo = result.getFirst();
+        assertThat(podInfo.getName()).isEqualTo("pod-with-restarts");
+        assertThat(podInfo.getRestartCount()).isEqualTo(5);
+        assertThat(podInfo.getLastTerminationReason()).isEqualTo("OOMKilled");
+        assertThat(podInfo.getLastExitCode()).isEqualTo(137);
+        assertThat(podInfo.getLastSignal()).isEqualTo(9);
+    }
+
+    @Test
+    void getInstances_shouldReturnPodsWithoutTerminationInfo() {
+        // Given
+        var podList = new PodList();
+        var pod = createPod("pod-no-restarts", true);
+        podList.setItems(List.of(pod));
+
+        when(k8sKserveClient.getServicePods(NAMESPACE, GENERATED_SERVICE_NAME)).thenReturn(podList);
+
+        // When
+        var result = inferenceDeploymentManager.getInstances(DEPLOYMENT_ID);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var podInfo = result.getFirst();
+        assertThat(podInfo.getName()).isEqualTo("pod-no-restarts");
+        assertThat(podInfo.getRestartCount()).isEqualTo(0);
+        assertThat(podInfo.getLastTerminationReason()).isNull();
+        assertThat(podInfo.getLastExitCode()).isNull();
+        assertThat(podInfo.getLastSignal()).isNull();
+    }
+
+    @Test
+    void getInstances_shouldAggregateRestartCountsFromMultipleContainers() {
+        // Given
+        var podList = new PodList();
+        var pod = createPodWithMultipleContainers("pod-multi-container", 3, 2);
+        podList.setItems(List.of(pod));
+
+        when(k8sKserveClient.getServicePods(NAMESPACE, GENERATED_SERVICE_NAME)).thenReturn(podList);
+
+        // When
+        var result = inferenceDeploymentManager.getInstances(DEPLOYMENT_ID);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var podInfo = result.getFirst();
+        assertThat(podInfo.getName()).isEqualTo("pod-multi-container");
+        assertThat(podInfo.getRestartCount()).isEqualTo(5); // 3 + 2
+    }
+
+    @Test
     void getContainerResource_shouldReturnContainerResourceForPod() {
         // Given
         Pod pod = createPod(POD_NAME, true);
@@ -713,6 +776,75 @@ class InferenceDeploymentManagerTest {
         var container = new Container();
         container.setName(CONTAINER_NAME);
         spec.setContainers(List.of(container));
+        pod.setSpec(spec);
+
+        return pod;
+    }
+
+    private Pod createPodWithRestartInfo(String name, int restartCount, String terminationReason, Integer exitCode, Integer signal) {
+        var pod = new Pod();
+        pod.setMetadata(new ObjectMeta());
+        pod.getMetadata().setName(name);
+        pod.getMetadata().setCreationTimestamp(Instant.now().toString());
+
+        var status = new PodStatus();
+        var containerStatus = new ContainerStatus();
+        containerStatus.setName(CONTAINER_NAME);
+        containerStatus.setRestartCount(restartCount);
+
+        // Set last terminated state
+        var terminatedState = new ContainerStateBuilder()
+                .withNewTerminated()
+                .withReason(terminationReason)
+                .withExitCode(exitCode)
+                .withSignal(signal)
+                .withFinishedAt(Instant.now().toString())
+                .endTerminated()
+                .build();
+        containerStatus.setLastState(terminatedState);
+
+        // Set current state as running
+        containerStatus.setState(new ContainerStateBuilder().build());
+
+        status.setContainerStatuses(List.of(containerStatus));
+        pod.setStatus(status);
+
+        var spec = new PodSpec();
+        var container = new Container();
+        container.setName(CONTAINER_NAME);
+        spec.setContainers(List.of(container));
+        pod.setSpec(spec);
+
+        return pod;
+    }
+
+    private Pod createPodWithMultipleContainers(String name, int restartCount1, int restartCount2) {
+        var pod = new Pod();
+        pod.setMetadata(new ObjectMeta());
+        pod.getMetadata().setName(name);
+        pod.getMetadata().setCreationTimestamp(Instant.now().toString());
+
+        var status = new PodStatus();
+        
+        var containerStatus1 = new ContainerStatus();
+        containerStatus1.setName(CONTAINER_NAME);
+        containerStatus1.setRestartCount(restartCount1);
+        containerStatus1.setState(new ContainerStateBuilder().build());
+
+        var containerStatus2 = new ContainerStatus();
+        containerStatus2.setName("sidecar-container");
+        containerStatus2.setRestartCount(restartCount2);
+        containerStatus2.setState(new ContainerStateBuilder().build());
+
+        status.setContainerStatuses(List.of(containerStatus1, containerStatus2));
+        pod.setStatus(status);
+
+        var spec = new PodSpec();
+        var container1 = new Container();
+        container1.setName(CONTAINER_NAME);
+        var container2 = new Container();
+        container2.setName("sidecar-container");
+        spec.setContainers(List.of(container1, container2));
         pod.setSpec(spec);
 
         return pod;

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
@@ -204,6 +204,50 @@ class KnativeDeploymentManagerTest {
     }
 
     @Test
+    void getInstances_shouldReturnPodsWithRestartInfo() {
+        // Given
+        var podList = new PodList();
+        var pod = createPodWithRestartInfo("pod-with-restarts", 5, "OOMKilled", 137, 9);
+        podList.setItems(List.of(pod));
+
+        when(k8sKnativeClient.getServicePods(NAMESPACE, SERVICE_NAME)).thenReturn(podList);
+
+        // When
+        var result = knativeDeploymentManager.getInstances(DEPLOYMENT_ID);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var podInfo = result.getFirst();
+        assertThat(podInfo.getName()).isEqualTo("pod-with-restarts");
+        assertThat(podInfo.getRestartCount()).isEqualTo(5);
+        assertThat(podInfo.getLastTerminationReason()).isEqualTo("OOMKilled");
+        assertThat(podInfo.getLastExitCode()).isEqualTo(137);
+        assertThat(podInfo.getLastSignal()).isEqualTo(9);
+    }
+
+    @Test
+    void getInstances_shouldReturnPodsWithoutTerminationInfo() {
+        // Given
+        var podList = new PodList();
+        var pod = createPod("pod-no-restarts", true);
+        podList.setItems(List.of(pod));
+
+        when(k8sKnativeClient.getServicePods(NAMESPACE, SERVICE_NAME)).thenReturn(podList);
+
+        // When
+        var result = knativeDeploymentManager.getInstances(DEPLOYMENT_ID);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var podInfo = result.getFirst();
+        assertThat(podInfo.getName()).isEqualTo("pod-no-restarts");
+        assertThat(podInfo.getRestartCount()).isEqualTo(0);
+        assertThat(podInfo.getLastTerminationReason()).isNull();
+        assertThat(podInfo.getLastExitCode()).isNull();
+        assertThat(podInfo.getLastSignal()).isNull();
+    }
+
+    @Test
     void getContainerResource_shouldReturnContainerResourceForPod() {
         // Given
         Pod pod = createPod(POD_NAME, true);
@@ -524,6 +568,43 @@ class KnativeDeploymentManagerTest {
         } else {
             containerStatus.setState(new ContainerStateBuilder().withNewWaiting().withReason("NotReady").endWaiting().build());
         }
+
+        status.setContainerStatuses(List.of(containerStatus));
+        pod.setStatus(status);
+
+        var spec = new PodSpec();
+        var container = new Container();
+        container.setName(SERVICE_CONTAINER);
+        spec.setContainers(List.of(container));
+        pod.setSpec(spec);
+
+        return pod;
+    }
+
+    private Pod createPodWithRestartInfo(String name, int restartCount, String terminationReason, Integer exitCode, Integer signal) {
+        var pod = new Pod();
+        pod.setMetadata(new ObjectMeta());
+        pod.getMetadata().setName(name);
+        pod.getMetadata().setCreationTimestamp(Instant.now().toString());
+
+        var status = new PodStatus();
+        var containerStatus = new ContainerStatus();
+        containerStatus.setName(SERVICE_CONTAINER);
+        containerStatus.setRestartCount(restartCount);
+
+        // Set last terminated state
+        var terminatedState = new ContainerStateBuilder()
+                .withNewTerminated()
+                .withReason(terminationReason)
+                .withExitCode(exitCode)
+                .withSignal(signal)
+                .withFinishedAt(Instant.now().toString())
+                .endTerminated()
+                .build();
+        containerStatus.setLastState(terminatedState);
+
+        // Set current state as running
+        containerStatus.setState(new ContainerStateBuilder().build());
 
         status.setContainerStatuses(List.of(containerStatus));
         pod.setStatus(status);

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
@@ -153,6 +153,50 @@ class NimDeploymentManagerTest {
     }
 
     @Test
+    void getInstances_shouldReturnPodsWithRestartInfo() {
+        // Given
+        var podList = new PodList();
+        var pod = createPodWithRestartInfo("pod-with-restarts", 5, "OOMKilled", 137, 9);
+        podList.setItems(List.of(pod));
+
+        when(k8sNimClient.getServicePods(NAMESPACE, SERVICE_NAME)).thenReturn(podList);
+
+        // When
+        var result = nimDeploymentManager.getInstances(DEPLOYMENT_ID);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var podInfo = result.getFirst();
+        assertThat(podInfo.getName()).isEqualTo("pod-with-restarts");
+        assertThat(podInfo.getRestartCount()).isEqualTo(5);
+        assertThat(podInfo.getLastTerminationReason()).isEqualTo("OOMKilled");
+        assertThat(podInfo.getLastExitCode()).isEqualTo(137);
+        assertThat(podInfo.getLastSignal()).isEqualTo(9);
+    }
+
+    @Test
+    void getInstances_shouldReturnPodsWithoutTerminationInfo() {
+        // Given
+        var podList = new PodList();
+        var pod = createPod("pod-no-restarts", true);
+        podList.setItems(List.of(pod));
+
+        when(k8sNimClient.getServicePods(NAMESPACE, SERVICE_NAME)).thenReturn(podList);
+
+        // When
+        var result = nimDeploymentManager.getInstances(DEPLOYMENT_ID);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var podInfo = result.getFirst();
+        assertThat(podInfo.getName()).isEqualTo("pod-no-restarts");
+        assertThat(podInfo.getRestartCount()).isEqualTo(0);
+        assertThat(podInfo.getLastTerminationReason()).isNull();
+        assertThat(podInfo.getLastExitCode()).isNull();
+        assertThat(podInfo.getLastSignal()).isNull();
+    }
+
+    @Test
     void getContainerResource_shouldReturnContainerResourceForPod() {
         // Given
         Pod pod = createPod(POD_NAME, true);
@@ -540,6 +584,43 @@ class NimDeploymentManagerTest {
         } else {
             containerStatus.setState(new ContainerStateBuilder().withNewWaiting().withReason("NotReady").endWaiting().build());
         }
+
+        status.setContainerStatuses(List.of(containerStatus));
+        pod.setStatus(status);
+
+        var spec = new PodSpec();
+        var container = new Container();
+        container.setName(CONTAINER_NAME);
+        spec.setContainers(List.of(container));
+        pod.setSpec(spec);
+
+        return pod;
+    }
+
+    private Pod createPodWithRestartInfo(String name, int restartCount, String terminationReason, Integer exitCode, Integer signal) {
+        var pod = new Pod();
+        pod.setMetadata(new ObjectMeta());
+        pod.getMetadata().setName(name);
+        pod.getMetadata().setCreationTimestamp(Instant.now().toString());
+
+        var status = new PodStatus();
+        var containerStatus = new ContainerStatus();
+        containerStatus.setName(CONTAINER_NAME);
+        containerStatus.setRestartCount(restartCount);
+
+        // Set last terminated state
+        var terminatedState = new ContainerStateBuilder()
+                .withNewTerminated()
+                .withReason(terminationReason)
+                .withExitCode(exitCode)
+                .withSignal(signal)
+                .withFinishedAt(Instant.now().toString())
+                .endTerminated()
+                .build();
+        containerStatus.setLastState(terminatedState);
+
+        // Set current state as running
+        containerStatus.setState(new ContainerStateBuilder().build());
 
         status.setContainerStatuses(List.of(containerStatus));
         pod.setStatus(status);

--- a/src/test/java/com/epam/aidial/deployment/manager/web/controller/none/DeploymentControllerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/web/controller/none/DeploymentControllerTest.java
@@ -356,6 +356,7 @@ class DeploymentControllerTest extends AbstractControllerNoneSecureTest {
 
     @Test
     void testGetPods_withRestartInfo() throws Exception {
+        var dtoJson = ResourceUtils.readResource("/mcp/deployment/pods_with_restart_info_response.json");
         var createdAt = Instant.parse("2023-01-01T12:00:00Z");
         var podInfo = new PodInfo("pod-1", createdAt, 5, "OOMKilled", 137, 9);
 
@@ -363,10 +364,39 @@ class DeploymentControllerTest extends AbstractControllerNoneSecureTest {
 
         mockMvc.perform(get("/api/v1/deployments/{id}/pods", DEPLOYMENT_ID))
                 .andExpect(status().isOk())
-                .andExpect(content().json(
-                        "[{\"name\":\"pod-1\",\"createdAt\":\"2023-01-01T12:00:00Z\",\"restartCount\":5,\"lastTerminationReason\":\"OOMKilled\",\"lastExitCode\":137,\"lastSignal\":9}]"));
+                .andExpect(content().json(dtoJson, JsonCompareMode.LENIENT));
 
         verify(deploymentService).getInstances(DEPLOYMENT_ID);
+    }
+
+    @Test
+    void testGetPods_withoutTerminationInfo() throws Exception {
+        var dtoJson = ResourceUtils.readResource("/mcp/deployment/pods_without_termination_info_response.json");
+        var createdAt = Instant.parse("2023-01-01T12:00:00Z");
+        var podInfo = new PodInfo("pod-2", createdAt, 0, null, null, null);
+
+        when(deploymentService.getInstances(DEPLOYMENT_ID)).thenReturn(List.of(podInfo));
+
+        mockMvc.perform(get("/api/v1/deployments/{id}/pods", DEPLOYMENT_ID))
+                .andExpect(status().isOk())
+                .andExpect(content().json(dtoJson, JsonCompareMode.LENIENT));
+
+        verify(deploymentService).getInstances(DEPLOYMENT_ID);
+    }
+
+    @Test
+    void testGetActivePods() throws Exception {
+        var dtoJson = ResourceUtils.readResource("/mcp/deployment/active_pods_response.json");
+        var createdAt = Instant.parse("2023-01-01T12:00:00Z");
+        var podInfo = new PodInfo("pod-3", createdAt, 2, "Error", 1, null);
+
+        when(deploymentService.getActiveInstances(DEPLOYMENT_ID)).thenReturn(List.of(podInfo));
+
+        mockMvc.perform(get("/api/v1/deployments/{id}/active-pods", DEPLOYMENT_ID))
+                .andExpect(status().isOk())
+                .andExpect(content().json(dtoJson, JsonCompareMode.LENIENT));
+
+        verify(deploymentService).getActiveInstances(DEPLOYMENT_ID);
     }
 
     private static SseEmitter completedEmitter() {

--- a/src/test/java/com/epam/aidial/deployment/manager/web/controller/none/DeploymentControllerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/web/controller/none/DeploymentControllerTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.deployment.manager.kubernetes.event.EventStreamerConfigur
 import com.epam.aidial.deployment.manager.model.EventType;
 import com.epam.aidial.deployment.manager.model.McpImageDefinition;
 import com.epam.aidial.deployment.manager.model.ObjectKind;
+import com.epam.aidial.deployment.manager.model.PodInfo;
 import com.epam.aidial.deployment.manager.model.deployment.McpDeployment;
 import com.epam.aidial.deployment.manager.service.ImageDefinitionService;
 import com.epam.aidial.deployment.manager.service.McpEndpointPathResolver;
@@ -351,6 +352,21 @@ class DeploymentControllerTest extends AbstractControllerNoneSecureTest {
         assertThat(cfg.sinceTime()).isEqualTo(sinceTime);
         assertThat(cfg.eventType()).isEqualTo(eventType);
         assertThat(cfg.involvedObjectKind()).isEqualTo(involvedObjectKind);
+    }
+
+    @Test
+    void testGetPods_withRestartInfo() throws Exception {
+        var createdAt = Instant.parse("2023-01-01T12:00:00Z");
+        var podInfo = new PodInfo("pod-1", createdAt, 5, "OOMKilled", 137, 9);
+
+        when(deploymentService.getInstances(DEPLOYMENT_ID)).thenReturn(List.of(podInfo));
+
+        mockMvc.perform(get("/api/v1/deployments/{id}/pods", DEPLOYMENT_ID))
+                .andExpect(status().isOk())
+                .andExpect(content().json(
+                        "[{\"name\":\"pod-1\",\"createdAt\":\"2023-01-01T12:00:00Z\",\"restartCount\":5,\"lastTerminationReason\":\"OOMKilled\",\"lastExitCode\":137,\"lastSignal\":9}]"));
+
+        verify(deploymentService).getInstances(DEPLOYMENT_ID);
     }
 
     private static SseEmitter completedEmitter() {

--- a/src/test/resources/mcp/deployment/active_pods_response.json
+++ b/src/test/resources/mcp/deployment/active_pods_response.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "pod-3",
+    "createdAt": 1672574400000,
+    "restartCount": 2,
+    "lastTerminationReason": "Error",
+    "lastExitCode": 1
+  }
+]

--- a/src/test/resources/mcp/deployment/pods_with_restart_info_response.json
+++ b/src/test/resources/mcp/deployment/pods_with_restart_info_response.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "pod-1",
+    "createdAt": 1672574400000,
+    "restartCount": 5,
+    "lastTerminationReason": "OOMKilled",
+    "lastExitCode": 137,
+    "lastSignal": 9
+  }
+]

--- a/src/test/resources/mcp/deployment/pods_without_termination_info_response.json
+++ b/src/test/resources/mcp/deployment/pods_without_termination_info_response.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "pod-2",
+    "createdAt": 1672574400000,
+    "restartCount": 0
+  }
+]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #48

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Enhance pods api, so it returns restarts count, failure reason, exit code, error signal
- Add tests

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.