### PR TITLE
chore: improve exception handling

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/dao/repository/RepositoryDatabaseExceptionAspect.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/repository/RepositoryDatabaseExceptionAspect.java
@@ -1,0 +1,34 @@
+package com.epam.aidial.deployment.manager.dao.repository;
+
+import com.epam.aidial.deployment.manager.exception.DatabaseException;
+import jakarta.persistence.PersistenceException;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wraps low-level database exceptions thrown from {@code com.epam.aidial.deployment.manager.dao.repository}
+ * into a {@link DatabaseException} to prevent leaking SQL/JPA provider details to the API layer.
+ */
+@Aspect
+@Component
+@Slf4j
+public class RepositoryDatabaseExceptionAspect {
+
+    @Around("execution(public * com.epam.aidial.deployment.manager.dao.repository..*(..))")
+    public Object wrapRepositoryDatabaseExceptions(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            return joinPoint.proceed();
+        } catch (DataAccessException | PersistenceException e) {
+            log.warn("Database exception in {}.{}()",
+                    joinPoint.getSignature().getDeclaringTypeName(),
+                    joinPoint.getSignature().getName(),
+                    e);
+            throw new DatabaseException("Database operation failed", e);
+        }
+    }
+}
+

--- a/src/main/java/com/epam/aidial/deployment/manager/exception/DatabaseException.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/exception/DatabaseException.java
@@ -1,0 +1,15 @@
+package com.epam.aidial.deployment.manager.exception;
+
+/**
+ * Exception indicating a database-related failure.
+ *
+ * <p>This exception is intended to be thrown at the DAO/repository layer boundary to avoid leaking
+ * vendor-specific SQL/JPA exception details outside the service.
+ */
+public class DatabaseException extends RuntimeException {
+
+    public DatabaseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.deployment.manager.web.handler;
 
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
+import com.epam.aidial.deployment.manager.exception.DatabaseException;
 import com.epam.aidial.deployment.manager.exception.DeploymentException;
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
 import com.epam.aidial.deployment.manager.exception.ImageInUseException;
@@ -40,7 +41,6 @@ public class DefaultExceptionHandler {
         return new ErrorView(req, HttpStatus.NOT_FOUND, ex.getMessage());
     }
 
-
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
     @ExceptionHandler({HttpRequestMethodNotSupportedException.class})
     public ErrorView handleMethodNotAllowedError(HttpServletRequest req, Exception ex) {
@@ -77,11 +77,18 @@ public class DefaultExceptionHandler {
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(DatabaseException.class)
+    public ErrorView handleDatabaseException(HttpServletRequest req, DatabaseException ex) {
+        log.warn("[{}] Request: {} failed due to database error", req.getMethod(), req.getServletPath(), ex);
+        return new ErrorView(req, HttpStatus.INTERNAL_SERVER_ERROR, "Database error occurred");
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     public ErrorView handleGeneralError(HttpServletRequest req, Exception ex) {
         log.warn("[{}] Request: {} raised exception", req.getMethod(), req.getServletPath(), ex);
 
-        return new ErrorView(req, HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return new ErrorView(req, HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/epam/aidial/deployment/manager/web/handler/ErrorView.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/handler/ErrorView.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
 
+import java.util.Objects;
+
 @Data
 public class ErrorView {
 
@@ -19,6 +21,28 @@ public class ErrorView {
         this.method = request.getMethod();
         this.status = status.value();
         this.error = status.getReasonPhrase();
-        this.message = errorMessage;
+        this.message = sanitizeMessage(errorMessage);
+    }
+
+    /**
+     * Best-effort sanitization to prevent accidental stacktrace leakage in API responses.
+     *
+     * <p>The API should not rely on this method for correctness; error messages should be sanitized at the
+     * exception handling layer. This is a last line of defense.
+     */
+    private static String sanitizeMessage(String message) {
+        String safe = Objects.requireNonNullElse(message, "");
+        if (safe.contains("\n\tat ") || safe.contains("\n at ")) {
+            // Strip typical Java stack trace lines and only keep the first line.
+            int firstLineEnd = safe.indexOf('\n');
+            safe = firstLineEnd >= 0 ? safe.substring(0, firstLineEnd) : safe;
+        }
+
+        // Defensive cap to avoid returning huge payloads due to accidental propagation of verbose messages.
+        int maxChars = 2000;
+        if (safe.length() > maxChars) {
+            safe = safe.substring(0, maxChars);
+        }
+        return safe;
     }
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #83 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Added DatabaseException that is intended to be thrown at the DAO/repository layer boundary to avoid leaking vendor-specific SQL/JPA exception details outside the service
- Added RepositoryDatabaseExceptionAspect that wraps DataAccessException & PersistenceException thrown by classes that belong to 'com.epam.aidial.deployment.manager.dao.repository' package
- Changed error view message to generic 'Internal server error' for generic exceptions to avoid leakage of internal details
- Added message sanitization to ErrorView to prevent accidental stacktrace leakage in API responses for potential uncovered scenarios

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.