### PR TITLE
fix: use 'dm' prefix for image copy and wrapper jobs

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageCopyJobSpecification.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageCopyJobSpecification.java
@@ -62,7 +62,7 @@ public class ImageCopyJobSpecification implements JobSpecification {
         var config = new MappingChain<>(this.appConfig.cloneCopyImageJobConfig());
         config.get(Mappers.JOB_METADATA_FIELD)
                 .data()
-                .setName(K8sNamingUtils.generateMcpPrefixedName(jobId));
+                .setName(K8sNamingUtils.generateName(jobId));
         var podSpec = config.get(Mappers.JOB_SPEC_FIELD)
                 .get(Mappers.JOB_TEMPLATE_FIELD)
                 .get(Mappers.JOB_TEMPLATE_SPEC_FIELD);

--- a/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageWrapperBuildJobSpecification.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageWrapperBuildJobSpecification.java
@@ -83,7 +83,7 @@ public class ImageWrapperBuildJobSpecification implements JobSpecification {
         var config = new MappingChain<>(this.appConfig.cloneBuilderJobConfig());
         config.get(Mappers.JOB_METADATA_FIELD)
                 .data()
-                .setName(K8sNamingUtils.generateMcpPrefixedName(buildId));
+                .setName(K8sNamingUtils.generateName(buildId));
         var podSpec = config.get(Mappers.JOB_SPEC_FIELD)
                 .get(Mappers.JOB_TEMPLATE_FIELD)
                 .get(Mappers.JOB_TEMPLATE_SPEC_FIELD);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- related to #32 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Changed prefix for image copy and wrapper jobs from 'mcp' to 'dm' to match with analyser job. This will also resolve issues with unlinked Cilium network policies.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.