### PR TITLE
fix: allow 0 for gpu resource request/limit

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/web/validation/ResourcesValidator.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/validation/ResourcesValidator.java
@@ -94,13 +94,16 @@ public class ResourcesValidator implements ConstraintValidator<ValidResources, R
                                            double requestNumeric,
                                            double limitNumeric,
                                            ConstraintValidatorContext context) {
-        // Lower bound check: both values must be greater than 0
-        if (requestNumeric <= 0 || limitNumeric <= 0) {
-            log.warn("Validation failed for '{}': values must be greater than 0 (request={}, limit={})",
-                    key, requestNumeric, limitNumeric);
+        // Define lower bound based on key
+        double lowerBound = NVIDIA_GPU.equals(key) ? 0 : 1;
+        String comparison = lowerBound == 0 ? "greater than or equal to 0" : "greater than 0";
+
+        if (requestNumeric < lowerBound || limitNumeric < lowerBound) {
+            log.warn("Validation failed for '{}': values must be {} (request={}, limit={})",
+                    key, comparison, requestNumeric, limitNumeric);
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(
-                            "Request and limit values for '%s' must be greater than 0".formatted(key))
+                            "Request and limit values for '%s' must be %s".formatted(key, comparison))
                     .addConstraintViolation();
             return false;
         }

--- a/src/test/java/com/epam/aidial/deployment/manager/validation/ResourcesValidatorTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/validation/ResourcesValidatorTest.java
@@ -79,8 +79,8 @@ class ResourcesValidatorTest {
     @Test
     void testLimitEqualToRequest() {
         var dto = mock(ResourcesDto.class);
-        when(dto.limits()).thenReturn(Map.of(CPU, "2", MEMORY, "4"));
-        when(dto.requests()).thenReturn(Map.of(CPU, "2", MEMORY, "4"));
+        when(dto.limits()).thenReturn(Map.of(CPU, "2", MEMORY, "4", NVIDIA_GPU, "0"));
+        when(dto.requests()).thenReturn(Map.of(CPU, "2", MEMORY, "4", NVIDIA_GPU, "0"));
         assertTrue(validator.isValid(dto, context));
     }
 
@@ -119,6 +119,17 @@ class ResourcesValidatorTest {
         assertFalse(validator.isValid(dto, context));
         verify(context).disableDefaultConstraintViolation();
         verify(context).buildConstraintViolationWithTemplate(contains("must be greater than 0"));
+    }
+
+    @Test
+    void testGpuValuesMustBeGreaterThanOrEqualToZero() {
+        var dto = mock(ResourcesDto.class);
+        when(dto.limits()).thenReturn(Map.of(NVIDIA_GPU, "0"));
+        when(dto.requests()).thenReturn(Map.of(NVIDIA_GPU, "-1"));
+
+        assertFalse(validator.isValid(dto, context));
+        verify(context).disableDefaultConstraintViolation();
+        verify(context).buildConstraintViolationWithTemplate(contains("must be greater than or equal to 0"));
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #115 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Changed validation for deployment resources to allow zero in 'nvidia.com/gpu' request and limit values.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.