### PR TITLE
fix: allow resource limits and requests values be <1 and >0

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/web/validation/ResourcesValidator.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/validation/ResourcesValidator.java
@@ -95,8 +95,9 @@ public class ResourcesValidator implements ConstraintValidator<ValidResources, R
                                            double limitNumeric,
                                            ConstraintValidatorContext context) {
         // Define lower bound based on key
-        double lowerBound = NVIDIA_GPU.equals(key) ? 0 : 1;
-        String comparison = lowerBound == 0 ? "greater than or equal to 0" : "greater than 0";
+        boolean isNvidiaGpu = NVIDIA_GPU.equals(key);
+        double lowerBound = isNvidiaGpu ? 0 : Double.MIN_VALUE;
+        String comparison = isNvidiaGpu ? "greater than or equal to 0" : "greater than 0";
 
         if (requestNumeric < lowerBound || limitNumeric < lowerBound) {
             log.warn("Validation failed for '{}': values must be {} (request={}, limit={})",

--- a/src/test/java/com/epam/aidial/deployment/manager/validation/ResourcesValidatorTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/validation/ResourcesValidatorTest.java
@@ -79,8 +79,8 @@ class ResourcesValidatorTest {
     @Test
     void testLimitEqualToRequest() {
         var dto = mock(ResourcesDto.class);
-        when(dto.limits()).thenReturn(Map.of(CPU, "2", MEMORY, "4", NVIDIA_GPU, "0"));
-        when(dto.requests()).thenReturn(Map.of(CPU, "2", MEMORY, "4", NVIDIA_GPU, "0"));
+        when(dto.limits()).thenReturn(Map.of(CPU, "0.5", MEMORY, "4", NVIDIA_GPU, "0"));
+        when(dto.requests()).thenReturn(Map.of(CPU, "0.5", MEMORY, "4", NVIDIA_GPU, "0"));
         assertTrue(validator.isValid(dto, context));
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- related to #115 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Allow resource limits and requests to have values less than 1 and bigger than 0.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.