### PR TITLE
feat: return logs for previously terminated containers

### DIFF
--- a/docs/rest-collection/dm_postman_collection.json
+++ b/docs/rest-collection/dm_postman_collection.json
@@ -935,7 +935,7 @@
                       }
                     ],
                     "url": {
-                      "raw": "{{HOST}}/api/v1/deployments/{{DEPLOYMENT_NAME}}/pods/{{POD_ID}}/logs",
+                      "raw": "{{HOST}}/api/v1/deployments/{{DEPLOYMENT_NAME}}/pods/{{POD_ID}}/logs?previous=false",
                       "host": [
                         "{{HOST}}"
                       ],
@@ -947,6 +947,12 @@
                         "pods",
                         "{{POD_ID}}",
                         "logs"
+                      ],
+                      "query": [
+                        {
+                          "key": "previous",
+                          "value": "false"
+                        }
                       ]
                     }
                   },

--- a/src/main/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReader.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReader.java
@@ -4,11 +4,10 @@ import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.Loggable;
 import io.fabric8.kubernetes.client.dsl.TailPrettyLoggable;
+import io.fabric8.kubernetes.client.dsl.TimeTailPrettyLoggable;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-
-import io.fabric8.kubernetes.client.dsl.TimeTailPrettyLoggable;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/main/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReader.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReader.java
@@ -8,6 +8,8 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import io.fabric8.kubernetes.client.dsl.TimeTailPrettyLoggable;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +28,7 @@ public class PodLogReader {
     private final Integer tailLogs;
     private final Integer sinceSeconds;
     private final Instant sinceTime;
+    private final boolean previous;
 
     public PodLogReader(PodLogReaderConfiguration configuration) {
         if (configuration.sinceSeconds() != null && configuration.sinceTime() != null) {
@@ -38,6 +41,7 @@ public class PodLogReader {
         this.tailLogs = assertGreaterThenZero(configuration.tailLogs(), "tailLogs");
         this.sinceSeconds = assertGreaterThenZero(configuration.sinceSeconds(), "sinceSeconds");
         this.sinceTime = configuration.sinceTime();
+        this.previous = configuration.previous();
     }
 
     private static Integer assertGreaterThenZero(Integer value, String name) {
@@ -58,15 +62,20 @@ public class PodLogReader {
     }
 
     private Loggable getLoggable(ContainerResource containerResource) {
-        TailPrettyLoggable loggable;
-        if (sinceTime != null) {
-            loggable = containerResource.sinceTime(sinceTime.toString());
-        } else if (sinceSeconds != null) {
-            loggable = containerResource.sinceSeconds(sinceSeconds);
-        } else {
-            loggable = containerResource;
-        }
+        var baseResource = previous
+                ? containerResource.terminated()
+                : containerResource;
+        var loggable = applySinceFilter(baseResource);
         return tailLogs != null ? loggable.tailingLines(tailLogs) : loggable;
+    }
+
+    private TailPrettyLoggable applySinceFilter(TimeTailPrettyLoggable resource) {
+        if (sinceTime != null) {
+            return resource.sinceTime(sinceTime.toString());
+        } else if (sinceSeconds != null) {
+            return resource.sinceSeconds(sinceSeconds);
+        }
+        return resource;
     }
 
     private void readOutputStream(InputStream logStream, Consumer<List<String>> logConsumer) throws IOException {

--- a/src/main/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReaderConfiguration.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReaderConfiguration.java
@@ -11,6 +11,7 @@ public record PodLogReaderConfiguration(
         @Min(1) Integer maxLogSize,
         @Min(1) Integer tailLogs,
         @Min(1) Integer sinceSeconds,
-        Instant sinceTime
+        Instant sinceTime,
+        boolean previous
 ) {
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/web/controller/DeploymentController.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/controller/DeploymentController.java
@@ -161,12 +161,14 @@ public class DeploymentController {
             @PathVariable(value = "podId") String podId,
             @RequestParam(value = "sinceTime", required = false) Instant sinceTime,
             @RequestParam(value = "sinceSeconds", required = false) Integer sinceSeconds,
-            @RequestParam(value = "tail", required = false) Integer tailLogs
+            @RequestParam(value = "tail", required = false) Integer tailLogs,
+            @RequestParam(value = "previous", required = false, defaultValue = "false") boolean previous
     ) {
         var logReadConfig = PodLogReaderConfiguration.builder()
                 .sinceTime(sinceTime)
                 .sinceSeconds(sinceSeconds)
                 .tailLogs(tailLogs)
+                .previous(previous)
                 .build();
         return deploymentLogsService.streamLogs(id, podId, logReadConfig);
     }

--- a/src/test/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReaderTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReaderTest.java
@@ -9,10 +9,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,47 +24,55 @@ class PodLogReaderTest {
     @Mock
     private ContainerResource containerResourceMock;
     @Mock
-    private LogWatch logWatchMock;
+    private LogWatch containerLogWatchMock;
     @Mock
-    private TimeTailPrettyLoggable timeTailPrettyLoggableMock;
-
+    private LogWatch terminatedLogWatchMock;
     @Mock
-    private Consumer<List<String>> consumerMock;
+    private TimeTailPrettyLoggable terminatedResourceMock;
 
     @Test
-    void readLogs_shouldCallTerminated_whenPreviousIsTrue() {
+    void readLogs_shouldReadFromTerminatedContainer_whenPreviousIsTrue() {
         // Given
-        var config = PodLogReaderConfiguration.builder()
-                .previous(true)
-                .build();
+        var config = PodLogReaderConfiguration.builder().previous(true).build();
         var reader = new PodLogReader(config);
 
-        when(containerResourceMock.terminated()).thenReturn(timeTailPrettyLoggableMock);
-        when(timeTailPrettyLoggableMock.watchLog()).thenReturn(logWatchMock);
-        when(logWatchMock.getOutput()).thenReturn(new ByteArrayInputStream("log line".getBytes()));
+        String terminatedLogs = "terminated container log line";
+        when(containerResourceMock.terminated()).thenReturn(terminatedResourceMock);
+        when(terminatedResourceMock.watchLog()).thenReturn(terminatedLogWatchMock);
+        when(terminatedLogWatchMock.getOutput()).thenReturn(new ByteArrayInputStream(terminatedLogs.getBytes()));
+
+        List<String> capturedLogs = new ArrayList<>();
+        Consumer<List<String>> consumer = capturedLogs::addAll;
 
         // When
-        reader.readLogs(containerResourceMock, consumerMock);
+        reader.readLogs(containerResourceMock, consumer);
 
         // Then
         verify(containerResourceMock).terminated();
+        verify(terminatedResourceMock).watchLog();
+        verifyNoInteractions(containerLogWatchMock);
+        assertThat(capturedLogs).containsExactly(terminatedLogs);
     }
 
     @Test
-    void readLogs_shouldNotCallTerminated_whenPreviousIsFalse() {
+    void readLogs_shouldReadFromCurrentContainer_whenPreviousIsFalse() {
         // Given
-        var config = PodLogReaderConfiguration.builder()
-                .previous(false)
-                .build();
+        var config = PodLogReaderConfiguration.builder().previous(false).build();
         var reader = new PodLogReader(config);
 
-        when(containerResourceMock.watchLog()).thenReturn(logWatchMock);
-        when(logWatchMock.getOutput()).thenReturn(new ByteArrayInputStream("log line".getBytes()));
+        String currentLogs = "current container log line";
+        when(containerResourceMock.watchLog()).thenReturn(containerLogWatchMock);
+        when(containerLogWatchMock.getOutput()).thenReturn(new ByteArrayInputStream(currentLogs.getBytes()));
+
+        List<String> capturedLogs = new ArrayList<>();
+        Consumer<List<String>> consumer = capturedLogs::addAll;
 
         // When
-        reader.readLogs(containerResourceMock, consumerMock);
+        reader.readLogs(containerResourceMock, consumer);
 
         // Then
         verify(containerResourceMock).watchLog();
+        verifyNoInteractions(terminatedResourceMock);
+        assertThat(capturedLogs).containsExactly(currentLogs);
     }
 }

--- a/src/test/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReaderTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/kubernetes/PodLogReaderTest.java
@@ -1,0 +1,67 @@
+package com.epam.aidial.deployment.manager.kubernetes;
+
+import io.fabric8.kubernetes.client.dsl.ContainerResource;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.kubernetes.client.dsl.TimeTailPrettyLoggable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PodLogReaderTest {
+
+    @Mock
+    private ContainerResource containerResourceMock;
+    @Mock
+    private LogWatch logWatchMock;
+    @Mock
+    private TimeTailPrettyLoggable timeTailPrettyLoggableMock;
+
+    @Mock
+    private Consumer<List<String>> consumerMock;
+
+    @Test
+    void readLogs_shouldCallTerminated_whenPreviousIsTrue() {
+        // Given
+        var config = PodLogReaderConfiguration.builder()
+                .previous(true)
+                .build();
+        var reader = new PodLogReader(config);
+
+        when(containerResourceMock.terminated()).thenReturn(timeTailPrettyLoggableMock);
+        when(timeTailPrettyLoggableMock.watchLog()).thenReturn(logWatchMock);
+        when(logWatchMock.getOutput()).thenReturn(new ByteArrayInputStream("log line".getBytes()));
+
+        // When
+        reader.readLogs(containerResourceMock, consumerMock);
+
+        // Then
+        verify(containerResourceMock).terminated();
+    }
+
+    @Test
+    void readLogs_shouldNotCallTerminated_whenPreviousIsFalse() {
+        // Given
+        var config = PodLogReaderConfiguration.builder()
+                .previous(false)
+                .build();
+        var reader = new PodLogReader(config);
+
+        when(containerResourceMock.watchLog()).thenReturn(logWatchMock);
+        when(logWatchMock.getOutput()).thenReturn(new ByteArrayInputStream("log line".getBytes()));
+
+        // When
+        reader.readLogs(containerResourceMock, consumerMock);
+
+        // Then
+        verify(containerResourceMock).watchLog();
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #76

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Implement a flag that extends the log retrieval method to return logs from previously stopped containers

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.