### PR TITLE
fix: set author from context on deployment duplicate

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
@@ -209,6 +209,7 @@ public class DeploymentService {
                 .orElseThrow(() -> new EntityNotFoundException("Etalon deployment not found by id: '%s'".formatted(etalonDeploymentId)));
 
         var createDeployment = deploymentMapper.toCreateCloneDeployment(etalonDeployment, cloneDeploymentId, cloneDeploymentDisplayName);
+        createDeployment.setAuthor(securityClaimsExtractor.getEmail());
 
         return createDeployment(createDeployment);
     }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #110 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
On deployment duplication operation, set author from security context instead of copying it from original deployment.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.