### PR TITLE
fix: separate cilium policy update from rolling update

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -108,7 +108,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                 @Override
                 public void afterCommit() {
                     try {
-                        createCiliumNetworkPolicy(id, deployment.getAllowedDomains(), deployment.getContainerPort());
+                        createCiliumNetworkPolicy(id, deployment.getAllowedDomains(), getCiliumIngressPorts(deployment));
                         createService(namespace, serviceSpec);
                     } catch (Exception e) {
                         var errorMessage = "Failed to deploy service '%s'".formatted(id);
@@ -603,8 +603,8 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         return disposableResources;
     }
 
-    private void createCiliumNetworkPolicy(String groupId, List<String> allowedDomains, Integer containerPort) {
-        log.trace("createCiliumNetworkPolicy. groupId='{}', allowedDomains={}", groupId, allowedDomains);
+    private void createCiliumNetworkPolicy(String groupId, List<String> allowedDomains, List<Integer> ports) {
+        log.trace("createCiliumNetworkPolicy. groupId='{}', allowedDomains={}, ports={}", groupId, allowedDomains, ports);
         if (!ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()) {
             log.debug("Cilium Network Policies are not enabled. Skipping creation.");
             return;
@@ -613,7 +613,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         var serviceName = getServiceName(groupId);
         log.trace("createCiliumNetworkPolicy. serviceNameLabel='{}', serviceName='{}'", serviceNameLabel, serviceName);
 
-        var ciliumNetworkPolicy = ciliumNetworkPolicyCreator.create(namespace, serviceNameLabel, serviceName, allowedDomains, containerPort);
+        var ciliumNetworkPolicy = ciliumNetworkPolicyCreator.create(namespace, serviceNameLabel, serviceName, allowedDomains, ports);
 
         disposableResourceManager.saveK8sResources(List.of(ciliumNetworkPolicy), K8sResourceKind.CILIUM_NETWORK_POLICY, groupId, namespace);
         log.trace("createCiliumNetworkPolicy. Saved Cilium Network Policy as disposable resource for groupId='{}' in namespace='{}'", groupId, namespace);
@@ -628,7 +628,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         var deployment = getDeployment(id);
 
         try {
-            updateCiliumNetworkPolicy(id, deployment.getAllowedDomains(), deployment.getContainerPort());
+            updateCiliumNetworkPolicy(id, deployment.getAllowedDomains(), getCiliumIngressPorts(deployment));
         } catch (Exception e) {
             var errorMessage = "Cilium Network Policy update failed for deployment '%s'".formatted(id);
             log.warn(errorMessage, e);
@@ -636,8 +636,8 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         }
     }
 
-    private void updateCiliumNetworkPolicy(String groupId, List<String> allowedDomains, Integer containerPort) {
-        log.trace("updateCiliumNetworkPolicy. groupId='{}', allowedDomains={}", groupId, allowedDomains);
+    private void updateCiliumNetworkPolicy(String groupId, List<String> allowedDomains, List<Integer> ports) {
+        log.trace("updateCiliumNetworkPolicy. groupId='{}', allowedDomains={}, ports={}", groupId, allowedDomains, ports);
         if (!ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()) {
             log.debug("Cilium Network Policies are not enabled. Skipping update.");
             return;
@@ -646,7 +646,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         var serviceName = getServiceName(groupId);
         log.trace("updateCiliumNetworkPolicy. serviceNameLabel='{}', serviceName='{}'", serviceNameLabel, serviceName);
 
-        var ciliumNetworkPolicy = ciliumNetworkPolicyCreator.create(namespace, serviceNameLabel, serviceName, allowedDomains, containerPort);
+        var ciliumNetworkPolicy = ciliumNetworkPolicyCreator.create(namespace, serviceNameLabel, serviceName, allowedDomains, ports);
 
         k8sClient.updateCiliumNetworkPolicy(namespace, ciliumNetworkPolicy);
         log.trace("updateCiliumNetworkPolicy. Updated Cilium Network Policy: {}", ciliumNetworkPolicy);
@@ -667,6 +667,11 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                 log.debug("{}. Cilium Network Policies are disabled", message);
             }
         }
+    }
+
+    protected List<Integer> getCiliumIngressPorts(Deployment deployment) {
+        var port = deployment.getContainerPort();
+        return port != null ? List.of(port) : null;
     }
 
     private Map<String, String> transformEnvs(Map<String, EnvVarValue> envs) {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -623,7 +623,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
     }
 
     @Override
-    @Transactional(isolation = Isolation.REPEATABLE_READ)
+    @Transactional
     public void updateCiliumNetworkPolicy(String id) {
         var deployment = getDeployment(id);
 

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -46,9 +46,11 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -603,7 +605,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         return disposableResources;
     }
 
-    private void createCiliumNetworkPolicy(String groupId, List<String> allowedDomains, List<Integer> ports) {
+    private void createCiliumNetworkPolicy(String groupId, List<String> allowedDomains, Set<Integer> ports) {
         log.trace("createCiliumNetworkPolicy. groupId='{}', allowedDomains={}, ports={}", groupId, allowedDomains, ports);
         if (!ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()) {
             log.debug("Cilium Network Policies are not enabled. Skipping creation.");
@@ -636,7 +638,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         }
     }
 
-    private void updateCiliumNetworkPolicy(String groupId, List<String> allowedDomains, List<Integer> ports) {
+    private void updateCiliumNetworkPolicy(String groupId, List<String> allowedDomains, Set<Integer> ports) {
         log.trace("updateCiliumNetworkPolicy. groupId='{}', allowedDomains={}, ports={}", groupId, allowedDomains, ports);
         if (!ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()) {
             log.debug("Cilium Network Policies are not enabled. Skipping update.");
@@ -669,9 +671,11 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         }
     }
 
-    protected List<Integer> getCiliumIngressPorts(D deployment) {
-        var port = deployment.getContainerPort();
-        return port != null ? List.of(port) : null;
+    protected Set<Integer> getCiliumIngressPorts(D deployment) {
+        Set<Integer> ports = new HashSet<>();
+        Optional.ofNullable(deployment.getContainerPort()).ifPresent(ports::add);
+        Optional.ofNullable(defaultContainerPort).ifPresent(ports::add);
+        return ports;
     }
 
     private Map<String, String> transformEnvs(Map<String, EnvVarValue> envs) {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -669,7 +669,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         }
     }
 
-    protected List<Integer> getCiliumIngressPorts(Deployment deployment) {
+    protected List<Integer> getCiliumIngressPorts(D deployment) {
         var port = deployment.getContainerPort();
         return port != null ? List.of(port) : null;
     }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -188,7 +188,6 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                 @Override
                 public void afterCommit() {
                     try {
-                        updateCiliumNetworkPolicy(id, deployment.getAllowedDomains(), deployment.getContainerPort());
                         updateService(namespace, serviceSpec);
                     } catch (Exception e) {
                         var errorMessage = "Rolling update failed for deployment '%s'".formatted(id);
@@ -621,6 +620,20 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
 
         k8sClient.createCiliumNetworkPolicy(namespace, ciliumNetworkPolicy);
         log.trace("createCiliumNetworkPolicy. Created Cilium Network Policy: {}", ciliumNetworkPolicy);
+    }
+
+    @Override
+    @Transactional(isolation = Isolation.REPEATABLE_READ)
+    public void updateCiliumNetworkPolicy(String id) {
+        var deployment = getDeployment(id);
+
+        try {
+            updateCiliumNetworkPolicy(id, deployment.getAllowedDomains(), deployment.getContainerPort());
+        } catch (Exception e) {
+            var errorMessage = "Cilium Network Policy update failed for deployment '%s'".formatted(id);
+            log.warn(errorMessage, e);
+            throw new DeploymentException(errorMessage, e);
+        }
     }
 
     private void updateCiliumNetworkPolicy(String groupId, List<String> allowedDomains, Integer containerPort) {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentManager.java
@@ -29,6 +29,8 @@ public interface DeploymentManager<S> {
 
     void rollingUpdate(String id);
 
+    void updateCiliumNetworkPolicy(String id);
+
     List<PodInfo> getActiveInstances(String id);
 
     List<PodInfo> getInstances(String id);

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
@@ -173,6 +173,11 @@ public class DeploymentService {
 
         var updatedDeployment = deploymentRepository.update(id, deployment);
 
+        boolean isApplicableForCiliumNetworkPolicyUpdate = isApplicableForCiliumNetworkPolicyUpdate(existingDeploymentWithResolvedSecrets, updatedDeployment);
+        if (updatedDeployment.getStatus() == DeploymentStatus.RUNNING && isApplicableForCiliumNetworkPolicyUpdate) {
+            deploymentManager.updateCiliumNetworkPolicy(id);
+        }
+
         boolean isApplicableForRollingUpdate = isApplicableForRollingUpdate(existingDeploymentWithResolvedSecrets, updatedDeployment, envsAreChanged);
         if (updatedDeployment.getStatus() == DeploymentStatus.RUNNING && isApplicableForRollingUpdate) {
             deploymentManager.rollingUpdate(id);
@@ -355,8 +360,12 @@ public class DeploymentService {
                 || !Objects.equals(existing.getMinScale(), updated.getMinScale())
                 || !Objects.equals(existing.getMaxScale(), updated.getMaxScale())
                 || !Objects.equals(existing.getResources(), updated.getResources())
-                || !CollectionUtils.isEqualCollection(existing.getAllowedDomains(), updated.getAllowedDomains())
                 || isGrpcUpdated;
+    }
+
+    private static boolean isApplicableForCiliumNetworkPolicyUpdate(Deployment existing, Deployment updated) {
+        return !CollectionUtils.isEqualCollection(existing.getAllowedDomains(), updated.getAllowedDomains())
+                || !Objects.equals(existing.getContainerPort(), updated.getContainerPort());
     }
 
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManager.java
@@ -25,7 +25,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Slf4j
 @Component
@@ -78,6 +80,17 @@ public class NimDeploymentManager extends AbstractModelDeploymentManager<NimDepl
             throw new IllegalArgumentException("Deployment type should be 'NIM' for NIM service deployment. Deployment: '%s'"
                     .formatted(deployment.getId()));
         });
+    }
+
+    @Override
+    protected List<Integer> getCiliumIngressPorts(Deployment deployment) {
+        if (deployment instanceof NimDeployment nimDeployment) {
+            var ports = Stream.of(nimDeployment.getContainerPort(), nimDeployment.getContainerGrpcPort())
+                    .filter(Objects::nonNull)
+                    .toList();
+            return ports.isEmpty() ? null : ports;
+        }
+        return super.getCiliumIngressPorts(deployment);
     }
 
     @Override

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManager.java
@@ -83,14 +83,11 @@ public class NimDeploymentManager extends AbstractModelDeploymentManager<NimDepl
     }
 
     @Override
-    protected List<Integer> getCiliumIngressPorts(Deployment deployment) {
-        if (deployment instanceof NimDeployment nimDeployment) {
-            var ports = Stream.of(nimDeployment.getContainerPort(), nimDeployment.getContainerGrpcPort())
-                    .filter(Objects::nonNull)
-                    .toList();
-            return ports.isEmpty() ? null : ports;
-        }
-        return super.getCiliumIngressPorts(deployment);
+    protected List<Integer> getCiliumIngressPorts(NimDeployment deployment) {
+        var ports = Stream.of(deployment.getContainerPort(), deployment.getContainerGrpcPort())
+                .filter(Objects::nonNull)
+                .toList();
+        return ports.isEmpty() ? null : ports;
     }
 
     @Override

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManager.java
@@ -25,9 +25,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -83,11 +82,10 @@ public class NimDeploymentManager extends AbstractModelDeploymentManager<NimDepl
     }
 
     @Override
-    protected List<Integer> getCiliumIngressPorts(NimDeployment deployment) {
-        var ports = Stream.of(deployment.getContainerPort(), deployment.getContainerGrpcPort())
-                .filter(Objects::nonNull)
-                .toList();
-        return ports.isEmpty() ? null : ports;
+    protected Set<Integer> getCiliumIngressPorts(NimDeployment deployment) {
+        var ports = super.getCiliumIngressPorts(deployment);
+        Optional.ofNullable(deployment.getContainerGrpcPort()).ifPresent(ports::add);
+        return ports;
     }
 
     @Override

--- a/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/CiliumNetworkPolicyCreator.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/CiliumNetworkPolicyCreator.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @Component
@@ -54,7 +55,7 @@ public class CiliumNetworkPolicyCreator {
                                       @NotNull String matchLabelName,
                                       @NotNull String matchLabelValue,
                                       @NotNull List<String> allowedDomains,
-                                      @Nullable List<Integer> ports) {
+                                      @Nullable Set<Integer> ports) {
         List<String> domains = new ArrayList<>(allowedDomains);
 
         // Detect if all egress to FQDNs should be allowed
@@ -156,7 +157,7 @@ public class CiliumNetworkPolicyCreator {
         return egress;
     }
 
-    private List<Ingress> createIngress(@Nullable List<Integer> ports) {
+    private List<Ingress> createIngress(@Nullable Set<Integer> ports) {
         FromEndpoints fromEndpoints = new FromEndpoints();
         fromEndpoints.setMatchLabels(Map.of(
                 KUBE_DNS_NAMESPACE_LABEL_NAME, "istio-system", APP, "istio-ingressgateway"

--- a/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/CiliumNetworkPolicyCreator.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/CiliumNetworkPolicyCreator.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Getter
 @Component
@@ -53,7 +54,7 @@ public class CiliumNetworkPolicyCreator {
                                       @NotNull String matchLabelName,
                                       @NotNull String matchLabelValue,
                                       @NotNull List<String> allowedDomains,
-                                      @Nullable Integer containerPort) {
+                                      @Nullable List<Integer> ports) {
         List<String> domains = new ArrayList<>(allowedDomains);
 
         // Detect if all egress to FQDNs should be allowed
@@ -81,7 +82,7 @@ public class CiliumNetworkPolicyCreator {
         }
         egressList.add(createKubeDnsEgress());
         spec.setEgress(egressList);
-        spec.setIngress(createIngress(containerPort));
+        spec.setIngress(createIngress(ports));
 
         // CiliumNetworkPolicy
         CiliumNetworkPolicy policy = new CiliumNetworkPolicy();
@@ -155,7 +156,7 @@ public class CiliumNetworkPolicyCreator {
         return egress;
     }
 
-    private List<Ingress> createIngress(@Nullable Integer containerPort) {
+    private List<Ingress> createIngress(@Nullable List<Integer> ports) {
         FromEndpoints fromEndpoints = new FromEndpoints();
         fromEndpoints.setMatchLabels(Map.of(
                 KUBE_DNS_NAMESPACE_LABEL_NAME, "istio-system", APP, "istio-ingressgateway"
@@ -182,21 +183,26 @@ public class CiliumNetworkPolicyCreator {
         port8022.setPort(INGRESS_PORT_8022);
         port8022.setProtocol(io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports.Protocol.TCP);
 
-        List<io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports> ports = new ArrayList<>();
-        ports.add(port8012);
-        ports.add(port8022);
+        List<io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports> ingressPorts = new ArrayList<>();
+        ingressPorts.add(port8012);
+        ingressPorts.add(port8022);
 
-        if (containerPort != null) {
-            io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports port =
-                    new io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports();
-            port.setPort(containerPort.toString());
-            port.setProtocol(io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports.Protocol.TCP);
-            ports.add(port);
+        if (CollectionUtils.isNotEmpty(ports)) {
+            ports.stream()
+                    .filter(Objects::nonNull)
+                    .map(port -> {
+                        io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports ingressPort =
+                                new io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports();
+                        ingressPort.setPort(port.toString());
+                        ingressPort.setProtocol(io.cilium.v2.ciliumnetworkpolicyspec.ingress.toports.Ports.Protocol.TCP);
+                        return ingressPort;
+                    })
+                    .forEach(ingressPorts::add);
         }
 
         io.cilium.v2.ciliumnetworkpolicyspec.ingress.ToPorts ingressToPorts =
                 new io.cilium.v2.ciliumnetworkpolicyspec.ingress.ToPorts();
-        ingressToPorts.setPorts(ports);
+        ingressToPorts.setPorts(ingressPorts);
 
         Ingress fromEndpointsIngressRule = new Ingress();
         fromEndpointsIngressRule.setFromEndpoints(List.of(fromEndpoints, fromEndpointsActivator, fromEndpointsAutoscaler));

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/DeploymentFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/DeploymentFunctionalTest.java
@@ -385,7 +385,51 @@ public abstract class DeploymentFunctionalTest {
         Assertions.assertEquals(savedDeployment.getId(), updatedDeployment.getId());
         Assertions.assertEquals(newImageDefinitionId, updatedDeployment.getImageDefinitionId());
 
-        verify(resource, times(2)).update();
+        verify(resource, times(1)).update();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldSuccessfullyUpdateCiliumNetworkPolicyIfRunningAndDomainsWereChanged() {
+        // Given
+        var createDeployment = FunctionalTestHelper.createInterceptorDeploymentRequest(imageDefinitionId);
+        var savedDeployment = deploymentService.createDeployment(createDeployment);
+
+        var mixedOperation = Mockito.mock(MixedOperation.class);
+        var resource = Mockito.mock(Resource.class);
+        var service = Mockito.mock(Service.class);
+        var metadata = Mockito.mock(ObjectMeta.class);
+        when(metadata.getAnnotations()).thenReturn(Map.of("serving.knative.dev/creator", "immutable-creator"));
+        when(service.getMetadata()).thenReturn(metadata);
+        when(resource.get()).thenReturn(service);
+        when(mixedOperation.inNamespace(any())).thenReturn(mixedOperation);
+        when(mixedOperation.withName(any())).thenReturn(resource);
+        when(mixedOperation.resource(any())).thenReturn(resource);
+        when(knativeClient.services()).thenReturn(mixedOperation);
+
+        when(kubernetesClient.resources(any(Class.class))).thenReturn(mixedOperation);
+
+        mockSecretMetaData(savedDeployment);
+
+        // When
+        savedDeployment.setStatus(DeploymentStatus.RUNNING);
+        deploymentRepository.update(savedDeployment.getId(), savedDeployment);
+
+        var allowedDomains = List.of("domain1.com", "domain2.com");
+
+        var updateRequest = FunctionalTestHelper.createInterceptorDeploymentRequest(imageDefinitionId);
+        updateRequest.setDisplayName("updated-deployment");
+        updateRequest.setAllowedDomains(allowedDomains);
+
+        var updatedDeployment = deploymentService.updateDeployment(savedDeployment.getId(), updateRequest);
+
+        // Then
+        Assertions.assertEquals("updated-deployment", updatedDeployment.getDisplayName());
+        Assertions.assertEquals(savedDeployment.getId(), updatedDeployment.getId());
+        Assertions.assertEquals(allowedDomains, updatedDeployment.getAllowedDomains());
+
+        // should update only once because cilium network policy should be updated and deployment shouldn't
+        verify(resource, times(1)).update();
     }
 
     @Test
@@ -484,8 +528,8 @@ public abstract class DeploymentFunctionalTest {
         deploymentService.updateImageDefinitionForDeployments(newImageDefinitionId, deploymentIds);
 
         // Then
-        // should update only twice because cilium network policy & deployment1 is active, and deployment2 isn't
-        verify(resource, times(2)).update();
+        // should update only once because deployment1 is active, and deployment2 isn't
+        verify(resource, times(1)).update();
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/DeploymentFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/DeploymentFunctionalTest.java
@@ -45,6 +45,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -395,19 +397,23 @@ public abstract class DeploymentFunctionalTest {
         var createDeployment = FunctionalTestHelper.createInterceptorDeploymentRequest(imageDefinitionId);
         var savedDeployment = deploymentService.createDeployment(createDeployment);
 
-        var mixedOperation = Mockito.mock(MixedOperation.class);
-        var resource = Mockito.mock(Resource.class);
+        var knativeMixedOperation = Mockito.mock(MixedOperation.class);
+        var knativeServiceResource = Mockito.mock(Resource.class);
         var service = Mockito.mock(Service.class);
         var metadata = Mockito.mock(ObjectMeta.class);
         when(metadata.getAnnotations()).thenReturn(Map.of("serving.knative.dev/creator", "immutable-creator"));
         when(service.getMetadata()).thenReturn(metadata);
-        when(resource.get()).thenReturn(service);
-        when(mixedOperation.inNamespace(any())).thenReturn(mixedOperation);
-        when(mixedOperation.withName(any())).thenReturn(resource);
-        when(mixedOperation.resource(any())).thenReturn(resource);
-        when(knativeClient.services()).thenReturn(mixedOperation);
+        when(knativeServiceResource.get()).thenReturn(service);
+        when(knativeMixedOperation.inNamespace(any())).thenReturn(knativeMixedOperation);
+        when(knativeMixedOperation.withName(any())).thenReturn(knativeServiceResource);
+        when(knativeMixedOperation.resource(any())).thenReturn(knativeServiceResource);
+        when(knativeClient.services()).thenReturn(knativeMixedOperation);
 
-        when(kubernetesClient.resources(any(Class.class))).thenReturn(mixedOperation);
+        var ciliumMixedOperation = Mockito.mock(MixedOperation.class);
+        var ciliumNetworkPolicyResource = Mockito.mock(Resource.class);
+        when(ciliumMixedOperation.inNamespace(any())).thenReturn(ciliumMixedOperation);
+        when(ciliumMixedOperation.resource(any())).thenReturn(ciliumNetworkPolicyResource);
+        when(kubernetesClient.resources(eq(CiliumNetworkPolicy.class))).thenReturn(ciliumMixedOperation);
 
         mockSecretMetaData(savedDeployment);
 
@@ -423,13 +429,16 @@ public abstract class DeploymentFunctionalTest {
 
         var updatedDeployment = deploymentService.updateDeployment(savedDeployment.getId(), updateRequest);
 
-        // Then
+        // Then - deployment metadata was updated in DB
         Assertions.assertEquals("updated-deployment", updatedDeployment.getDisplayName());
         Assertions.assertEquals(savedDeployment.getId(), updatedDeployment.getId());
         Assertions.assertEquals(allowedDomains, updatedDeployment.getAllowedDomains());
 
-        // should update only once because cilium network policy should be updated and deployment shouldn't
-        verify(resource, times(1)).update();
+        // Then - Cilium network policy was updated (domains change only triggers policy update)
+        verify(ciliumNetworkPolicyResource, times(1)).update();
+
+        // Then - Knative service was not updated
+        verify(knativeServiceResource, never()).update();
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -63,6 +64,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -208,7 +210,7 @@ public abstract class FullWorkflowWithMockedK8sClientFunctionalTest {
         Assertions.assertEquals(expectedService, service);
 
         var ciliumNetworkPolicy = cnpCaptor.getValue();
-        var expectedPorts = deployment.getContainerPort() != null ? List.of(deployment.getContainerPort()) : null;
+        var expectedPorts = Set.of(deployment.getContainerPort());
         var expectedCiliumNetworkPolicy = ciliumNetworkPolicyCreator.create("default", "serving.knative.dev/service",
                 serviceName, deployment.getAllowedDomains(), expectedPorts);
         Assertions.assertEquals(Serialization.asYaml(expectedCiliumNetworkPolicy), Serialization.asYaml(ciliumNetworkPolicy));
@@ -358,7 +360,10 @@ public abstract class FullWorkflowWithMockedK8sClientFunctionalTest {
         container.setImagePullPolicy("Always");
         container.setEnv(Arrays.asList(envDialUrl, envSensVar));
         container.setResources(resources);
-        container.setPorts(List.of());
+
+        var port = new ContainerPort();
+        port.setContainerPort(8080);
+        container.setPorts(List.of(port));
 
         // RevisionSpec
         var revisionSpec = new RevisionSpec();

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
@@ -208,8 +208,9 @@ public abstract class FullWorkflowWithMockedK8sClientFunctionalTest {
         Assertions.assertEquals(expectedService, service);
 
         var ciliumNetworkPolicy = cnpCaptor.getValue();
+        var expectedPorts = deployment.getContainerPort() != null ? List.of(deployment.getContainerPort()) : null;
         var expectedCiliumNetworkPolicy = ciliumNetworkPolicyCreator.create("default", "serving.knative.dev/service",
-                serviceName, deployment.getAllowedDomains(), deployment.getContainerPort());
+                serviceName, deployment.getAllowedDomains(), expectedPorts);
         Assertions.assertEquals(Serialization.asYaml(expectedCiliumNetworkPolicy), Serialization.asYaml(ciliumNetworkPolicy));
 
         Assertions.assertNotNull(deployedDeployment);

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/utils/FunctionalTestHelper.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/utils/FunctionalTestHelper.java
@@ -188,6 +188,7 @@ public class FunctionalTestHelper {
                 .resources(createResources())
                 .author("test-author")
                 .metadata(new DeploymentMetadata(envs))
+                .containerPort(8080)
                 .allowedDomains(List.of("github.com", "epam.com"))
                 .build();
     }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
@@ -306,7 +306,7 @@ class KnativeDeploymentManagerTest {
                 any()
         )).thenReturn(serviceSpec);
         when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
-        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(containerPort))).thenReturn(ciliumNetworkPolicy);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(List.of(containerPort)))).thenReturn(ciliumNetworkPolicy);
 
         // When
         Deployment result = knativeDeploymentManager.deploy(DEPLOYMENT_ID);
@@ -382,7 +382,7 @@ class KnativeDeploymentManagerTest {
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         )).thenReturn(serviceSpec);
         when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
-        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(containerPort))).thenReturn(ciliumNetworkPolicy);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(List.of(containerPort)))).thenReturn(ciliumNetworkPolicy);
         doThrow(new RuntimeException("Test exception")).when(k8sClient).createCiliumNetworkPolicy(eq(NAMESPACE), any());
 
         // When

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
@@ -51,6 +51,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -306,7 +307,7 @@ class KnativeDeploymentManagerTest {
                 any()
         )).thenReturn(serviceSpec);
         when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
-        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(List.of(containerPort)))).thenReturn(ciliumNetworkPolicy);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(Set.of(containerPort)))).thenReturn(ciliumNetworkPolicy);
 
         // When
         Deployment result = knativeDeploymentManager.deploy(DEPLOYMENT_ID);
@@ -382,7 +383,7 @@ class KnativeDeploymentManagerTest {
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         )).thenReturn(serviceSpec);
         when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
-        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(List.of(containerPort)))).thenReturn(ciliumNetworkPolicy);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), eq(Set.of(containerPort)))).thenReturn(ciliumNetworkPolicy);
         doThrow(new RuntimeException("Test exception")).when(k8sClient).createCiliumNetworkPolicy(eq(NAMESPACE), any());
 
         // When

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -95,6 +97,9 @@ class NimDeploymentManagerTest {
     private ContainerResource containerResource;
     @Mock
     private CiliumNetworkPolicy ciliumNetworkPolicy;
+
+    @Captor
+    private ArgumentCaptor<List<Integer>> ciliumPortsCaptor;
 
     private NimDeploymentManager nimDeploymentManager;
 
@@ -277,6 +282,44 @@ class NimDeploymentManagerTest {
         verify(disposableResourceManager).saveNimServiceResource(eq(DEPLOYMENT_ID), eq(NAMESPACE));
         verify(k8sNimClient).createService(eq(NAMESPACE), eq(serviceSpec));
         verify(deploymentRepository).updateStatus(eq(DEPLOYMENT_ID), eq(DeploymentStatus.PENDING));
+    }
+
+    @Test
+    void deploy_shouldPassContainerPortAndContainerGrpcPortToCiliumNetworkPolicyCreator() {
+        // Given
+        int containerPort = 8000;
+        int containerGrpcPort = 50052;
+
+        Deployment deployment = createDeployment(DeploymentStatus.STOPPED);
+        ((NimDeployment) deployment).setContainerGrpcPort(containerGrpcPort);
+        deployment.setContainerPort(containerPort);
+
+        NIMService serviceSpec = new NIMService();
+        serviceSpec.getMetadata().setName(SERVICE_NAME);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(nimManifestGenerator.serviceConfig(
+                eq(DEPLOYMENT_ID),
+                any(),
+                any(),
+                any(),
+                eq(IMAGE_NAME),
+                any(),
+                any(),
+                any()
+        )).thenReturn(serviceSpec);
+        when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), ciliumPortsCaptor.capture()))
+                .thenReturn(ciliumNetworkPolicy);
+
+        // When
+        nimDeploymentManager.deploy(DEPLOYMENT_ID);
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
+        // Then
+        verify(ciliumNetworkPolicyCreator).create(eq(NAMESPACE), anyString(), anyString(), anyList(), any());
+        List<Integer> portsPassedToCilium = ciliumPortsCaptor.getValue();
+        assertThat(portsPassedToCilium).containsExactly(containerPort, containerGrpcPort);
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
@@ -49,6 +49,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +70,7 @@ class NimDeploymentManagerTest {
     private static final String DEPLOYMENT_ID = String.valueOf(UUID.randomUUID());
     private static final UUID IMAGE_DEFINITION_ID = UUID.randomUUID();
     private static final int STARTUP_TIMEOUT = 60;
+    private static final int DEFAULT_NIM_SERVICE_PORT = 8000;
     private static final String NAMESPACE = "test-namespace";
     private static final String SERVICE_NAME = "mcp-" + DEPLOYMENT_ID;
     private static final String CONTAINER_NAME = "test-container";
@@ -99,7 +101,7 @@ class NimDeploymentManagerTest {
     private CiliumNetworkPolicy ciliumNetworkPolicy;
 
     @Captor
-    private ArgumentCaptor<List<Integer>> ciliumPortsCaptor;
+    private ArgumentCaptor<Set<Integer>> ciliumPortsCaptor;
 
     private NimDeploymentManager nimDeploymentManager;
 
@@ -287,7 +289,7 @@ class NimDeploymentManagerTest {
     @Test
     void deploy_shouldPassContainerPortAndContainerGrpcPortToCiliumNetworkPolicyCreator() {
         // Given
-        int containerPort = 8000;
+        int containerPort = 8002;
         int containerGrpcPort = 50052;
 
         Deployment deployment = createDeployment(DeploymentStatus.STOPPED);
@@ -318,8 +320,8 @@ class NimDeploymentManagerTest {
 
         // Then
         verify(ciliumNetworkPolicyCreator).create(eq(NAMESPACE), anyString(), anyString(), anyList(), any());
-        List<Integer> portsPassedToCilium = ciliumPortsCaptor.getValue();
-        assertThat(portsPassedToCilium).containsExactly(containerPort, containerGrpcPort);
+        Set<Integer> portsPassedToCilium = ciliumPortsCaptor.getValue();
+        assertThat(portsPassedToCilium).containsExactlyInAnyOrder(DEFAULT_NIM_SERVICE_PORT, containerPort, containerGrpcPort);
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #112 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Separated Cilium Network Policy update from Deployment rolling update. Policy should be updated only if allowedDomains or containerPort changed. Deployment rolling update should not happen if allowedDomains changed.
Additionally, added logic to include NIM gRPC port and default container port to Cilium policy.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.