### PR TITLE
feat!: add log4j2 config file and migrate to W3C trace context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,9 @@ dependencies {
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:1.33.6-alpha'
 
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.12.0')
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter:2.12.0'
+
     implementation 'org.mapstruct:mapstruct:1.6.0'
     annotationProcessor "org.mapstruct:mapstruct-processor:1.6.0"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,6 +370,61 @@ ai-dial-admin-backend/secrets-utils/generate_h2_secrets.sh can help to generate 
 | otel.metrics.exporter               | OTEL_METRICS_EXPORTER       | otlp                            | No       | -         | Exporter for application metrics                  |
 | otel.resource.attributes            | OTEL_RESOURCE_ATTRIBUTES    |                                 | No       | -         | Key-value pairs to be used as resource attributes |
 
+### Distributed Tracing
+
+The application uses OpenTelemetry for distributed tracing and automatically includes trace IDs in HTTP response headers and error responses. This enables request correlation across services and makes debugging easier using tools like Kibana or browser developer tools.
+
+#### Response Headers
+
+All HTTP responses include the following header (when OpenTelemetry trace context is available):
+
+- **`traceparent`**: W3C Trace Context standard header for interoperability. Format: `00-{trace-id}-{span-id}-{trace-flags}` (e.g., `00-5bf82f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`)
+
+#### Response Body Structure
+
+**Success Responses:**
+
+Success responses are returned as-is without wrapping. Trace IDs are available in `traceparent` response headers only.
+
+**Error Responses:**
+
+Error responses include trace information directly in the error object:
+
+```json
+{
+  "path": "/api/v1/deployments",
+  "method": "GET",
+  "status": 404,
+  "error": "Not Found",
+  "message": "Deployment not found",
+  "traceparent": "00-5bf82f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+}
+```
+
+#### Client Integration - Passing Trace Context
+
+To maintain OpenTelemetry trace context when making requests to this service, clients should:
+
+**Use `traceparent` header**: Send the W3C Trace Context header to propagate trace context:
+```
+traceparent: 00-{trace-id}-{span-id}-{trace-flags}
+```
+Example: `traceparent: 00-5bf82f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+
+The service will automatically extract and propagate the trace context. If no trace context is provided, the service will generate a new trace.
+
+**Frontend/Client Examples:**
+
+- **JavaScript/TypeScript**: Use OpenTelemetry JavaScript SDK to automatically inject `traceparent` header
+- **Manual**: Extract trace ID from previous response headers and include in subsequent requests
+- **Browser Developer Tools**: Inspect Network tab to see trace IDs in response headers
+
+#### Trace ID Generation
+
+- Trace IDs are extracted exclusively from OpenTelemetry span context
+- If OpenTelemetry is disabled (`otel.sdk.disabled=true`) or trace context is unavailable, headers may not be set
+- The service relies solely on OpenTelemetry for trace ID generation - no custom correlation ID logic
+
 ## Required Kubernetes RBAC
 
 The application needs scoped permissions in four namespaces:

--- a/src/main/java/com/epam/aidial/deployment/manager/configuration/logging/CorrelationIdInterceptor.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/configuration/logging/CorrelationIdInterceptor.java
@@ -1,72 +1,36 @@
 package com.epam.aidial.deployment.manager.configuration.logging;
 
-import io.opentelemetry.api.trace.Span;
+import com.epam.aidial.deployment.manager.utils.TraceContextUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.MDC;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import java.util.regex.Pattern;
-
+/**
+ * Interceptor that sets trace context headers in HTTP responses.
+ * Uses OpenTelemetry trace IDs exclusively via W3C Trace Context standard.
+ */
 @Slf4j
 public class CorrelationIdInterceptor implements HandlerInterceptor {
 
-    public static final String CORRELATION_ID_HEADER_NAME = "X-Correlation-Id";
-    private static final Pattern CORRELATION_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9]{16,32}$");
-    private static final String NOT_VALID_CORRELATION_ID = "00000000000000000000000000000000";
-    private static final int CORRELATION_ID_LENGTH = 16;
+    public static final String TRACEPARENT_HEADER_NAME = "traceparent";
 
     @Override
-    public boolean preHandle(@NotNull final HttpServletRequest request,
+    public boolean preHandle(final HttpServletRequest request,
                              final HttpServletResponse response,
-                             @NotNull final Object handler) {
-        response.setHeader(CORRELATION_ID_HEADER_NAME, resolveValidCorrelationId(request));
+                             final Object handler) {
+        // Set W3C Trace Context header for interoperability
+        String traceParent = TraceContextUtils.formatTraceParent();
+        if (traceParent != null) {
+            response.setHeader(TRACEPARENT_HEADER_NAME, traceParent);
+        }
+
         return true;
     }
 
     @Override
-    public void afterCompletion(@NotNull final HttpServletRequest request,
-                                @NotNull final HttpServletResponse response,
-                                @NotNull final Object handler,
-                                @NotNull final Exception ex) {
-        // do nothing
-    }
-
-    private String resolveValidCorrelationId(final HttpServletRequest request) {
-        var correlationId = request.getHeader(CORRELATION_ID_HEADER_NAME);
-        var validCorrelationId = (correlationId != null && CORRELATION_ID_PATTERN.matcher(correlationId).matches())
-                ? correlationId : generateCorrelationId();
-
-        MDC.put("_correlation_id", validCorrelationId);
-
-        if (!validCorrelationId.equals(correlationId)) {
-            var uri = request.getRequestURI();
-            var message = "Correlation ID '" + StringEscapeUtils.escapeJava(correlationId)
-                    + "' isn't valid, generated correlationId='" + validCorrelationId + "', url='" + uri + "'";
-            if (StringUtils.isBlank(correlationId)) {
-                log.debug(message);
-            } else {
-                log.error(message);
-            }
-        }
-
-        return validCorrelationId;
-    }
-
-    public static String generateCorrelationId() {
-        String traceId = Span.current().getSpanContext().getTraceId();
-        if (NOT_VALID_CORRELATION_ID.equals(traceId)) {
-            return generateRandomCorrelationId();
-        }
-        return traceId;
-    }
-
-    private static String generateRandomCorrelationId() {
-        return RandomStringUtils.randomAlphanumeric(CORRELATION_ID_LENGTH);
+    public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response,
+                                final Object handler, final Exception ex) {
+        // No cleanup needed
     }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/utils/TraceContextUtils.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/utils/TraceContextUtils.java
@@ -1,0 +1,80 @@
+package com.epam.aidial.deployment.manager.utils;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utility class for extracting trace context information from OpenTelemetry.
+ */
+@UtilityClass
+public class TraceContextUtils {
+
+    private static final String INVALID_TRACE_ID = "00000000000000000000000000000000";
+    private static final String INVALID_SPAN_ID = "0000000000000000";
+
+    /**
+     * Gets the current trace ID from OpenTelemetry span context.
+     *
+     * @return trace ID as hex string, or null if not available
+     */
+    public static String getTraceId() {
+        Span currentSpan = Span.current();
+        SpanContext spanContext = currentSpan.getSpanContext();
+        String traceId = spanContext.getTraceId();
+
+        if (!spanContext.isValid() || INVALID_TRACE_ID.equals(traceId)) {
+            return null;
+        }
+
+        return traceId;
+    }
+
+    /**
+     * Gets the current span ID from OpenTelemetry span context.
+     *
+     * @return span ID as hex string, or null if not available
+     */
+    public static String getSpanId() {
+        Span currentSpan = Span.current();
+        SpanContext spanContext = currentSpan.getSpanContext();
+        String spanId = spanContext.getSpanId();
+
+        if (!spanContext.isValid() || INVALID_SPAN_ID.equals(spanId)) {
+            return null;
+        }
+
+        return spanId;
+    }
+
+    /**
+     * Formats W3C Trace Context traceparent header value.
+     * Format: 00-{trace-id}-{span-id}-{trace-flags}
+     *
+     * @return W3C traceparent header value or null if trace context is invalid
+     */
+    public static String formatTraceParent() {
+        Span currentSpan = Span.current();
+        SpanContext spanContext = currentSpan.getSpanContext();
+
+        if (!spanContext.isValid()) {
+            return null;
+        }
+
+        String traceId = spanContext.getTraceId();
+        String spanId = spanContext.getSpanId();
+        TraceFlags traceFlags = spanContext.getTraceFlags();
+
+        if (INVALID_TRACE_ID.equals(traceId) || INVALID_SPAN_ID.equals(spanId)) {
+            return null;
+        }
+
+        // W3C Trace Context format: version-trace-id-parent-id-trace-flags
+        // version is always "00" (current version)
+        // trace-flags is 2 hex characters (01 = sampled, 00 = not sampled)
+        String flags = String.format("%02x", traceFlags.asByte() & 0xFF);
+
+        return String.format("00-%s-%s-%s", traceId, spanId, flags);
+    }
+}

--- a/src/main/java/com/epam/aidial/deployment/manager/web/handler/ErrorView.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/handler/ErrorView.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.deployment.manager.web.handler;
 
+import com.epam.aidial.deployment.manager.utils.TraceContextUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,14 @@ public class ErrorView {
     private String error;
     private String message;
 
+    /**
+     * W3C Trace Context traceparent value.
+     * Format: 00-{trace-id}-{span-id}-{trace-flags}
+     * Example: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+     * This enables distributed tracing correlation across services.
+     */
+    private String traceparent;
+
     public ErrorView(HttpServletRequest request, HttpStatus status, String errorMessage) {
 
         this.path = request.getServletPath();
@@ -22,6 +31,9 @@ public class ErrorView {
         this.status = status.value();
         this.error = status.getReasonPhrase();
         this.message = sanitizeMessage(errorMessage);
+
+        // Populate trace information from OpenTelemetry context
+        this.traceparent = TraceContextUtils.formatTraceParent();
     }
 
     /**

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="${env:LOGGER_STATUS_LOG_LEVEL:-WARN}">
+
+    <Properties>
+        <property name="APP_LOG_LEVEL">INFO</property> <!-- default value if not set -->
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout
+                    pattern="%style{%d{ISO8601}}{green} %highlight{%-5level} trace_id: %X{trace_id} span_id=%X{span_id} [%style{%t}{bright,blue}] %style{%c{1.}}{bright,yellow}: %msg%n%throwable"/>
+        </Console>
+        <OpenTelemetry name="OpenTelemetryAppender"/>
+    </Appenders>
+
+    <Loggers>
+        <Root level="${APP_LOG_LEVEL}">
+            <AppenderRef ref="OpenTelemetryAppender" level="All"/>
+            <AppenderRef ref="Console"/>
+        </Root>
+
+        <Logger name="com.epam" level="${env:APP_LOG_LEVEL}"/>
+    </Loggers>
+
+</Configuration>

--- a/src/test/java/com/epam/aidial/deployment/manager/configuration/logging/CorrelationIdInterceptorTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/configuration/logging/CorrelationIdInterceptorTest.java
@@ -1,0 +1,94 @@
+package com.epam.aidial.deployment.manager.configuration.logging;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CorrelationIdInterceptorTest {
+
+    private CorrelationIdInterceptor interceptor;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private OpenTelemetrySdk openTelemetrySdk;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new CorrelationIdInterceptor();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+
+        // Set up minimal OpenTelemetry SDK for testing
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder().build();
+
+        openTelemetrySdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .build();
+
+        // Set as global instance for the test
+        GlobalOpenTelemetry.set(openTelemetrySdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clean up OpenTelemetry
+        if (openTelemetrySdk != null) {
+            openTelemetrySdk.close();
+        }
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void testPreHandle_setsTraceParentHeader_whenOpenTelemetryContextExists() {
+        // given - create a span with OpenTelemetry
+        Tracer tracer = openTelemetrySdk.getTracer("test");
+        Span span = tracer.spanBuilder("test-span").startSpan();
+
+        try (Scope ignored = span.makeCurrent()) {
+            // when
+            boolean result = interceptor.preHandle(request, response, null);
+
+            // then
+            assertThat(result).isTrue();
+            String traceParent = response.getHeader(CorrelationIdInterceptor.TRACEPARENT_HEADER_NAME);
+            assertThat(traceParent).isNotNull();
+            assertThat(traceParent).matches("^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$");
+
+            // Verify format: 00-{trace-id}-{span-id}-{trace-flags}
+            String[] parts = traceParent.split("-");
+            assertThat(parts).hasSize(4);
+            assertThat(parts[0]).isEqualTo("00"); // version
+            assertThat(parts[1]).hasSize(32); // trace-id (32 hex chars)
+            assertThat(parts[2]).hasSize(16); // span-id (16 hex chars)
+            assertThat(parts[3]).hasSize(2); // trace-flags (2 hex chars)
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void testPreHandle_noTraceParentHeader_whenNoOpenTelemetryContext() {
+        // given - no active span context
+
+        // when
+        boolean result = interceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isTrue();
+        // When no OpenTelemetry context is available, traceparent may be null
+        // This is acceptable behavior - verify it's not set or null
+        String traceParent = response.getHeader(CorrelationIdInterceptor.TRACEPARENT_HEADER_NAME);
+        // verify traceParent can be null when no OpenTelemetry context exists, which is expected
+        // and interceptor should not throw exceptions even when trace context is unavailable
+        assertThat(traceParent).isNullOrEmpty();
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- carryover of https://github.com/epam/ai-dial-admin-backend/pull/455

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Add log4j2.xml file.

BREAKING CHANGE: Remove correlationId, use only traceparent header

- Remove X-Correlation-Id header and correlationId field
- Use traceparent header (W3C Trace Context standard) exclusively
- Update ErrorView to include traceparent property instead of traceId/spanId
- Remove MDC correlation_id from logging
- Simplify CorrelationIdInterceptor to only handle traceparent
- Update documentation with traceparent client integration guide
- Add OpenTelemetry SDK tests to verify traceparent header generation

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.