### PR TITLE
fix: change CNP disposable resource state to 'stable' after successful creation

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -613,6 +613,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         }
         var serviceNameLabel = getServiceNameLabel();
         var serviceName = getServiceName(groupId);
+        var cnpName = CiliumNetworkPolicyCreator.getPolicyName(serviceName);
         log.trace("createCiliumNetworkPolicy. serviceNameLabel='{}', serviceName='{}'", serviceNameLabel, serviceName);
 
         var ciliumNetworkPolicy = ciliumNetworkPolicyCreator.create(namespace, serviceNameLabel, serviceName, allowedDomains, ports);
@@ -622,6 +623,12 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
 
         k8sClient.createCiliumNetworkPolicy(namespace, ciliumNetworkPolicy);
         log.trace("createCiliumNetworkPolicy. Created Cilium Network Policy: {}", ciliumNetworkPolicy);
+
+        disposableResourceManager.changeResourceLifecycleByGroupIdInSameTransaction(
+                groupId,
+                new K8sResourceReference(this.namespace, K8sResourceKind.CILIUM_NETWORK_POLICY, cnpName),
+                ResourceLifecycleState.STABLE
+        );
     }
 
     @Override


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
Fixed bug when Cilium policies were cleaned up on scheduled/startup disposable resources cleanup.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.