### PR TITLE
fix: change CNP lifecycle in new transaction

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/cleanup/resource/DisposableResourceManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/cleanup/resource/DisposableResourceManager.java
@@ -100,6 +100,15 @@ public class DisposableResourceManager {
         changeResourceLifecycleInternal(groupId, resourceReference, state);
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void changeResourceLifecycleByGroupId(
+            String groupId,
+            ResourceReference resourceReference,
+            ResourceLifecycleState state
+    ) {
+        changeResourceLifecycleInternal(groupId, resourceReference, state);
+    }
+
     private List<DisposableResource> changeResourceLifecycleInternal(
             String groupId,
             ResourceReference resourceReference,
@@ -172,7 +181,7 @@ public class DisposableResourceManager {
         resourceRepository.save(imageResource);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteAll(List<DisposableResource> resources) {
         resourceRepository.deleteAll(resources);
     }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -624,7 +624,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         k8sClient.createCiliumNetworkPolicy(namespace, ciliumNetworkPolicy);
         log.trace("createCiliumNetworkPolicy. Created Cilium Network Policy: {}", ciliumNetworkPolicy);
 
-        disposableResourceManager.changeResourceLifecycleByGroupIdInSameTransaction(
+        disposableResourceManager.changeResourceLifecycleByGroupId(
                 groupId,
                 new K8sResourceReference(this.namespace, K8sResourceKind.CILIUM_NETWORK_POLICY, cnpName),
                 ResourceLifecycleState.STABLE


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Change Cilium Network Policy disposable resource lifecycle state to 'stable' in a new transaction (otherwise not reflected in DB)
- Change propagation to 'requires new' for 'deleteAll' in DisposableResourceManager to fix cases when resources stay in DB after they were cleaned up

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.