### PR TITLE
fix: handle MCP client exceptions

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/exception/McpClientException.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/exception/McpClientException.java
@@ -1,0 +1,17 @@
+package com.epam.aidial.deployment.manager.exception;
+
+/**
+ * Exception thrown when MCP client operation fails.
+ */
+public class McpClientException extends RuntimeException {
+
+    /**
+     * Creates a new McpClientException with the specified message and cause.
+     *
+     * @param message the error message
+     * @param cause   the cause of the exception
+     */
+    public McpClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/epam/aidial/deployment/manager/service/McpService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/McpService.java
@@ -2,6 +2,7 @@ package com.epam.aidial.deployment.manager.service;
 
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
+import com.epam.aidial.deployment.manager.exception.McpClientException;
 import com.epam.aidial.deployment.manager.model.DeploymentStatus;
 import com.epam.aidial.deployment.manager.model.deployment.McpDeployment;
 import com.epam.aidial.deployment.manager.service.deployment.DeploymentService;
@@ -41,6 +42,9 @@ public class McpService {
         try (var mcpClient = mcpClientFactory.create(deployment.getUrl(), endpointPath, deployment.getTransport())) {
             mcpClient.initialize();
             return function.apply(mcpClient, nextCursor);
+        } catch (Exception e) {
+            throw new McpClientException(("Failed to connect to MCP server. Make sure transport '%s' and path '%s' are correct."
+                    + " Deployment id: %s").formatted(deployment.getTransport(), deployment.getMcpEndpointPath(), deploymentId), e);
         }
     }
 

--- a/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
@@ -5,6 +5,7 @@ import com.epam.aidial.deployment.manager.exception.DatabaseException;
 import com.epam.aidial.deployment.manager.exception.DeploymentException;
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
 import com.epam.aidial.deployment.manager.exception.ImageInUseException;
+import com.epam.aidial.deployment.manager.exception.McpClientException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,12 @@ public class DefaultExceptionHandler {
 
     @ExceptionHandler(DeploymentException.class)
     public ErrorView handleDeploymentError(HttpServletRequest req, DeploymentException ex) {
+        logUncaught(ex);
+        return new ErrorView(req, HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+
+    @ExceptionHandler(McpClientException.class)
+    public ErrorView handleMcpClientError(HttpServletRequest req, McpClientException ex) {
         logUncaught(ex);
         return new ErrorView(req, HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/McpServiceTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/McpServiceTest.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.deployment.manager.service;
 
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
+import com.epam.aidial.deployment.manager.exception.McpClientException;
 import com.epam.aidial.deployment.manager.model.DeploymentStatus;
 import com.epam.aidial.deployment.manager.model.McpTransport;
 import com.epam.aidial.deployment.manager.model.deployment.McpDeployment;
@@ -174,7 +175,9 @@ class McpServiceTest {
         Mockito.doThrow(new TestException("Test exception")).when(mcpSyncClient).initialize();
 
         // When/Then
-        assertThrows(TestException.class, () -> mcpService.getTools(DEPLOYMENT_ID, NEXT_CURSOR));
+        var exception = assertThrows(McpClientException.class, () -> mcpService.getTools(DEPLOYMENT_ID, NEXT_CURSOR));
+
+        assertThat(exception).hasMessageContaining("Failed to connect to MCP server");
 
         verify(deploymentService).getDeployment(DEPLOYMENT_ID);
         verify(mcpClientFactory).create(DEPLOYMENT_URL, endpointPath, McpTransport.SSE);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #134 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added custom exception for MCP client related errors identification in default exception handler.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.