### PR TITLE
feat: support TCP socket startup probe

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/dao/entity/probe/PersistenceProbeHandler.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/entity/probe/PersistenceProbeHandler.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "$type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = PersistenceHttpGetProbe.class, name = "httpGet")
+        @JsonSubTypes.Type(value = PersistenceHttpGetProbe.class, name = "httpGet"),
+        @JsonSubTypes.Type(value = PersistenceTcpSocketProbe.class, name = "tcpSocket")
 })
 public interface PersistenceProbeHandler {
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/dao/entity/probe/PersistenceTcpSocketProbe.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/entity/probe/PersistenceTcpSocketProbe.java
@@ -1,0 +1,12 @@
+package com.epam.aidial.deployment.manager.dao.entity.probe;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PersistenceTcpSocketProbe implements PersistenceProbeHandler {
+    private int port;
+}

--- a/src/main/java/com/epam/aidial/deployment/manager/dao/mapper/PersistenceProbePropertiesMapper.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/mapper/PersistenceProbePropertiesMapper.java
@@ -3,9 +3,11 @@ package com.epam.aidial.deployment.manager.dao.mapper;
 import com.epam.aidial.deployment.manager.dao.entity.probe.PersistenceHttpGetProbe;
 import com.epam.aidial.deployment.manager.dao.entity.probe.PersistenceProbeHandler;
 import com.epam.aidial.deployment.manager.dao.entity.probe.PersistenceProbeProperties;
+import com.epam.aidial.deployment.manager.dao.entity.probe.PersistenceTcpSocketProbe;
 import com.epam.aidial.deployment.manager.model.probe.HttpGetProbe;
 import com.epam.aidial.deployment.manager.model.probe.ProbeHandler;
 import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
+import com.epam.aidial.deployment.manager.model.probe.TcpSocketProbe;
 import org.mapstruct.Mapper;
 import org.mapstruct.SubclassExhaustiveStrategy;
 import org.mapstruct.SubclassMapping;
@@ -18,8 +20,10 @@ public interface PersistenceProbePropertiesMapper {
     PersistenceProbeProperties toPersistenceProbeProperties(ProbeProperties domain);
 
     @SubclassMapping(source = PersistenceHttpGetProbe.class, target = HttpGetProbe.class)
+    @SubclassMapping(source = PersistenceTcpSocketProbe.class, target = TcpSocketProbe.class)
     ProbeHandler toProbeHandler(PersistenceProbeHandler entity);
 
     @SubclassMapping(source = HttpGetProbe.class, target = PersistenceHttpGetProbe.class)
+    @SubclassMapping(source = TcpSocketProbe.class, target = PersistenceTcpSocketProbe.class)
     PersistenceProbeHandler toPersistenceProbeHandler(ProbeHandler domain);
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/model/probe/ProbeHandler.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/model/probe/ProbeHandler.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "$type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = HttpGetProbe.class, name = "httpGet")
+        @JsonSubTypes.Type(value = HttpGetProbe.class, name = "httpGet"),
+        @JsonSubTypes.Type(value = TcpSocketProbe.class, name = "tcpSocket")
 })
 public interface ProbeHandler {
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/model/probe/TcpSocketProbe.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/model/probe/TcpSocketProbe.java
@@ -1,0 +1,12 @@
+package com.epam.aidial.deployment.manager.model.probe;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TcpSocketProbe implements ProbeHandler {
+    private int port;
+}

--- a/src/main/java/com/epam/aidial/deployment/manager/service/manifest/KserveProbeConverter.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/manifest/KserveProbeConverter.java
@@ -5,6 +5,7 @@ import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.kserve.serving.v1beta1.inferenceservicespec.predictor.model.StartupProbe;
 import io.kserve.serving.v1beta1.inferenceservicespec.predictor.model.startupprobe.HttpGet;
+import io.kserve.serving.v1beta1.inferenceservicespec.predictor.model.startupprobe.TcpSocket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
@@ -79,6 +80,11 @@ public class KserveProbeConverter {
             httpGet.setPath(source.getHttpGet().getPath());
             httpGet.setPort(source.getHttpGet().getPort());
             target.setHttpGet(httpGet);
+        }
+        if (source.getTcpSocket() != null) {
+            var tcpSocket = new TcpSocket();
+            tcpSocket.setPort(source.getTcpSocket().getPort());
+            target.setTcpSocket(tcpSocket);
         }
     }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/manifest/NimProbeConverter.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/manifest/NimProbeConverter.java
@@ -4,6 +4,7 @@ import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
 import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
 import com.nvidia.apps.v1alpha1.nimservicespec.StartupProbe;
 import com.nvidia.apps.v1alpha1.nimservicespec.startupprobe.probe.HttpGet;
+import com.nvidia.apps.v1alpha1.nimservicespec.startupprobe.probe.TcpSocket;
 import io.fabric8.kubernetes.api.model.Probe;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -84,6 +85,11 @@ public class NimProbeConverter {
             httpGet.setPath(source.getHttpGet().getPath());
             httpGet.setPort(source.getHttpGet().getPort());
             target.setHttpGet(httpGet);
+        }
+        if (source.getTcpSocket() != null) {
+            var tcpSocket = new TcpSocket();
+            tcpSocket.setPort(source.getTcpSocket().getPort());
+            target.setTcpSocket(tcpSocket);
         }
     }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/manifest/ProbeConverter.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/manifest/ProbeConverter.java
@@ -4,9 +4,11 @@ import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
 import com.epam.aidial.deployment.manager.model.probe.HttpGetProbe;
 import com.epam.aidial.deployment.manager.model.probe.ProbeHandler;
 import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
+import com.epam.aidial.deployment.manager.model.probe.TcpSocketProbe;
 import io.fabric8.kubernetes.api.model.HTTPGetAction;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.TCPSocketAction;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
@@ -53,6 +55,12 @@ public class ProbeConverter {
                     .httpPath(h.getPath())
                     .build();
         }
+        if (handler instanceof TcpSocketProbe tcp) {
+            return HandlerParams.builder()
+                    .handlerType("tcpSocket")
+                    .tcpPort(new IntOrString(tcp.getPort()))
+                    .build();
+        }
         return HandlerParams.builder().handlerType("unknown").build();
     }
 
@@ -62,17 +70,25 @@ public class ProbeConverter {
             @Nullable Integer timeoutSeconds,
             @Nullable Integer failureThreshold,
             HandlerParams params) {
-        if (params.httpPath() == null || params.httpPort() == null) {
-            log.warn("Probe must have httpGet handler with path and port. Probe not built.");
-            return null;
+        if (params.tcpPort() != null) {
+            var probe = new Probe();
+            setTimingOnProbe(probe, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold);
+            var tcpSocket = new TCPSocketAction();
+            tcpSocket.setPort(params.tcpPort());
+            probe.setTcpSocket(tcpSocket);
+            return probe;
         }
-        var probe = new Probe();
-        setTimingOnProbe(probe, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold);
-        var httpGet = new HTTPGetAction();
-        httpGet.setPath(params.httpPath());
-        httpGet.setPort(params.httpPort());
-        probe.setHttpGet(httpGet);
-        return probe;
+        if (params.httpPath() != null && params.httpPort() != null) {
+            var probe = new Probe();
+            setTimingOnProbe(probe, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold);
+            var httpGet = new HTTPGetAction();
+            httpGet.setPath(params.httpPath());
+            httpGet.setPort(params.httpPort());
+            probe.setHttpGet(httpGet);
+            return probe;
+        }
+        log.warn("Probe must have httpGet (path and port) or tcpSocket (port) handler. Probe not built.");
+        return null;
     }
 
     /**
@@ -108,6 +124,7 @@ public class ProbeConverter {
     private record HandlerParams(
             String handlerType,
             @Nullable IntOrString httpPort,
-            @Nullable String httpPath
+            @Nullable String httpPath,
+            @Nullable IntOrString tcpPort
     ) { }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/web/dto/probe/ProbeHandlerDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/dto/probe/ProbeHandlerDto.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
- * Marker interface for probe handler DTOs. Only httpGet is supported currently; more types may be
- * added later (e.g. tcpSocket, exec, grpc).
+ * Marker interface for probe handler DTOs.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "$type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = HttpGetProbeDto.class, name = "httpGet")
+        @JsonSubTypes.Type(value = HttpGetProbeDto.class, name = "httpGet"),
+        @JsonSubTypes.Type(value = TcpSocketProbeDto.class, name = "tcpSocket")
 })
 public interface ProbeHandlerDto {
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/web/dto/probe/TcpSocketProbeDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/dto/probe/TcpSocketProbeDto.java
@@ -1,0 +1,22 @@
+package com.epam.aidial.deployment.manager.web.dto.probe;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TcpSocketProbeDto implements ProbeHandlerDto {
+    /**
+     * Number of the port to access on the container.
+     */
+    @NotNull
+    @Min(1) @Max(65535)
+    private int port;
+}

--- a/src/main/java/com/epam/aidial/deployment/manager/web/mapper/ProbePropertiesDtoMapper.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/mapper/ProbePropertiesDtoMapper.java
@@ -3,9 +3,11 @@ package com.epam.aidial.deployment.manager.web.mapper;
 import com.epam.aidial.deployment.manager.model.probe.HttpGetProbe;
 import com.epam.aidial.deployment.manager.model.probe.ProbeHandler;
 import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
+import com.epam.aidial.deployment.manager.model.probe.TcpSocketProbe;
 import com.epam.aidial.deployment.manager.web.dto.probe.HttpGetProbeDto;
 import com.epam.aidial.deployment.manager.web.dto.probe.ProbeHandlerDto;
 import com.epam.aidial.deployment.manager.web.dto.probe.ProbePropertiesDto;
+import com.epam.aidial.deployment.manager.web.dto.probe.TcpSocketProbeDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.SubclassExhaustiveStrategy;
 import org.mapstruct.SubclassMapping;
@@ -18,8 +20,10 @@ public interface ProbePropertiesDtoMapper {
     ProbePropertiesDto toProbePropertiesDto(ProbeProperties model);
 
     @SubclassMapping(source = HttpGetProbeDto.class, target = HttpGetProbe.class)
+    @SubclassMapping(source = TcpSocketProbeDto.class, target = TcpSocketProbe.class)
     ProbeHandler toProbeHandler(ProbeHandlerDto dto);
 
     @SubclassMapping(source = HttpGetProbe.class, target = HttpGetProbeDto.class)
+    @SubclassMapping(source = TcpSocketProbe.class, target = TcpSocketProbeDto.class)
     ProbeHandlerDto toProbeHandlerDto(ProbeHandler model);
 }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/manifest/KserveProbeConverterTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/manifest/KserveProbeConverterTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.deployment.manager.service.manifest;
 
 import com.epam.aidial.deployment.manager.model.probe.HttpGetProbe;
 import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
+import com.epam.aidial.deployment.manager.model.probe.TcpSocketProbe;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,5 +40,19 @@ class KserveProbeConverterTest {
         assertThat(result.getPeriodSeconds()).isEqualTo(10);
         assertThat(result.getTimeoutSeconds()).isEqualTo(3);
         assertThat(result.getFailureThreshold()).isEqualTo(2);
+    }
+
+    @Test
+    void tcpSocket_returnsKserveStartupProbeWithTcpSocket() {
+        var tcpSocket = new TcpSocketProbe(6379);
+        var properties = new ProbeProperties(true, 5, 10, 3, 2, tcpSocket);
+
+        var result = kserveProbeConverter.toKserveStartupProbe(properties);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTcpSocket()).isNotNull();
+        assertThat(result.getTcpSocket().getPort().getIntVal()).isEqualTo(6379);
+        assertThat(result.getInitialDelaySeconds()).isEqualTo(5);
+        assertThat(result.getPeriodSeconds()).isEqualTo(10);
     }
 }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/manifest/NimProbeConverterTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/manifest/NimProbeConverterTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.deployment.manager.service.manifest;
 
 import com.epam.aidial.deployment.manager.model.probe.HttpGetProbe;
 import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
+import com.epam.aidial.deployment.manager.model.probe.TcpSocketProbe;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +38,22 @@ class NimProbeConverterTest {
         assertThat(result.getProbe().getHttpGet()).isNotNull();
         assertThat(result.getProbe().getHttpGet().getPath()).isEqualTo("/ready");
         assertThat(result.getProbe().getHttpGet().getPort().getIntVal()).isEqualTo(9090);
+        assertThat(result.getProbe().getInitialDelaySeconds()).isEqualTo(1);
+        assertThat(result.getProbe().getPeriodSeconds()).isEqualTo(5);
+    }
+
+    @Test
+    void tcpSocket_returnsNimStartupProbeWithEnabledAndTcpSocket() {
+        var tcpSocket = new TcpSocketProbe(6379);
+        var properties = new ProbeProperties(true, 1, 5, 1, 1, tcpSocket);
+
+        var result = nimProbeConverter.toNimStartupProbe(properties);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEnabled()).isTrue();
+        assertThat(result.getProbe()).isNotNull();
+        assertThat(result.getProbe().getTcpSocket()).isNotNull();
+        assertThat(result.getProbe().getTcpSocket().getPort().getIntVal()).isEqualTo(6379);
         assertThat(result.getProbe().getInitialDelaySeconds()).isEqualTo(1);
         assertThat(result.getProbe().getPeriodSeconds()).isEqualTo(5);
     }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/manifest/ProbeConverterTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/manifest/ProbeConverterTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.deployment.manager.service.manifest;
 
 import com.epam.aidial.deployment.manager.model.probe.HttpGetProbe;
 import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
+import com.epam.aidial.deployment.manager.model.probe.TcpSocketProbe;
 import io.fabric8.kubernetes.api.model.Probe;
 import org.junit.jupiter.api.Test;
 
@@ -60,5 +61,32 @@ class ProbeConverterTest {
 
         assertThat(probe).isNotNull();
         assertThat(probe.getHttpGet().getPort().getIntVal()).isEqualTo(8080);
+    }
+
+    @Test
+    void tcpSocket_convertsToProbeWithTcpSocketAndTiming() {
+        var tcpSocket = new TcpSocketProbe(9090);
+        var properties = new ProbeProperties(true, 5, 10, 3, 2, tcpSocket);
+
+        Probe probe = probeConverter.toProbe(properties);
+
+        assertThat(probe).isNotNull();
+        assertThat(probe.getInitialDelaySeconds()).isEqualTo(5);
+        assertThat(probe.getPeriodSeconds()).isEqualTo(10);
+        assertThat(probe.getTimeoutSeconds()).isEqualTo(3);
+        assertThat(probe.getFailureThreshold()).isEqualTo(2);
+        assertThat(probe.getTcpSocket()).isNotNull();
+        assertThat(probe.getTcpSocket().getPort().getIntVal()).isEqualTo(9090);
+    }
+
+    @Test
+    void tcpSocketWithPortOnly_usesIntOrStringPort() {
+        var tcpSocket = new TcpSocketProbe(6379);
+        var properties = new ProbeProperties(true, null, null, null, null, tcpSocket);
+
+        Probe probe = probeConverter.toProbe(properties);
+
+        assertThat(probe).isNotNull();
+        assertThat(probe.getTcpSocket().getPort().getIntVal()).isEqualTo(6379);
     }
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- related to #39 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added support for 'tcpSocket' startup probe type.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.