### PR TITLE
chore: update spring boot to 3.5.10 and enable postgres & sqlserver tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'java'
     id 'checkstyle'
     id 'io.freefair.lombok' version '8.10'
-    id 'org.springframework.boot' version '3.5.3'
+    id 'org.springframework.boot' version '3.5.10'
     id 'io.fabric8.java-generator' version "${fabric8_kubernetes_client_version}"
 }
 

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/PostgresFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/PostgresFunctionalTests.java
@@ -6,7 +6,6 @@ import com.epam.aidial.deployment.manager.functional.tests.FullWorkflowWithMocke
 import com.epam.aidial.deployment.manager.functional.tests.ImageDefinitionBuildFunctionalTest;
 import com.epam.aidial.deployment.manager.functional.tests.ImageDefinitionFunctionalTest;
 import com.epam.aidial.deployment.manager.functional.tests.TopicFunctionalTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -16,7 +15,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Disabled("temporary disabled due to infrastructure issues")
 @DataJpaTest
 @TestPropertySource(properties = {
         "datasource.vendor=POSTGRES",

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/PostgresFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/PostgresFunctionalTests.java
@@ -6,6 +6,7 @@ import com.epam.aidial.deployment.manager.functional.tests.FullWorkflowWithMocke
 import com.epam.aidial.deployment.manager.functional.tests.ImageDefinitionBuildFunctionalTest;
 import com.epam.aidial.deployment.manager.functional.tests.ImageDefinitionFunctionalTest;
 import com.epam.aidial.deployment.manager.functional.tests.TopicFunctionalTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -15,6 +16,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Disabled("temporary disabled due to infrastructure issues")
 @DataJpaTest
 @TestPropertySource(properties = {
         "datasource.vendor=POSTGRES",

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/SqlServerFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/SqlServerFunctionalTests.java
@@ -8,6 +8,7 @@ import com.epam.aidial.deployment.manager.functional.tests.ImageDefinitionFuncti
 import com.epam.aidial.deployment.manager.functional.tests.TopicFunctionalTest;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -22,6 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+@Disabled("temporary disabled due to infrastructure issues")
 @DataJpaTest
 @TestPropertySource(properties = {
         "datasource.vendor=MS_SQL_SERVER",

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/SqlServerFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/SqlServerFunctionalTests.java
@@ -8,7 +8,6 @@ import com.epam.aidial.deployment.manager.functional.tests.ImageDefinitionFuncti
 import com.epam.aidial.deployment.manager.functional.tests.TopicFunctionalTest;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -23,7 +22,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-@Disabled("temporary disabled due to infrastructure issues")
 @DataJpaTest
 @TestPropertySource(properties = {
         "datasource.vendor=MS_SQL_SERVER",


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
- 'org.springframework.boot' version updated to '3.5.10'
- PostgresFunctionalTest enabled
- SqlServerFunctionalTest enabled

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.