### PR TITLE
fix: allow zero for probe initial delay seconds

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/web/dto/probe/ProbePropertiesDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/dto/probe/ProbePropertiesDto.java
@@ -23,7 +23,7 @@ public class ProbePropertiesDto {
      * Number of seconds after the container has started before the probe is initiated.
      */
     @Nullable
-    @Min(1) @Max(6000)
+    @Min(0) @Max(6000)
     private Integer initialDelaySeconds;
     /**
      * How often (in seconds) to perform the probe.


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- related to #39 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Changed validation to allow '0' for initial delay seconds in deployment startup probe.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.