### PR TITLE
fix: perform deployment health checks after transaction commit

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/dao/repository/DeploymentRepository.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/repository/DeploymentRepository.java
@@ -128,6 +128,7 @@ public class DeploymentRepository {
         return mapper.toDomain(savedEntity);
     }
 
+    @Transactional(isolation = Isolation.REPEATABLE_READ)
     public boolean conditionalUpdate(String id, Predicate<Deployment> condition, Consumer<Deployment> mutator) {
         var existingEntity = findDeploymentById(id);
         var domainObject = mapper.toDomain(existingEntity);

--- a/src/main/java/com/epam/aidial/deployment/manager/dao/repository/DeploymentRepository.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/repository/DeploymentRepository.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -127,7 +128,6 @@ public class DeploymentRepository {
         return mapper.toDomain(savedEntity);
     }
 
-    @Transactional(isolation = Isolation.REPEATABLE_READ)
     public boolean conditionalUpdate(String id, Predicate<Deployment> condition, Consumer<Deployment> mutator) {
         var existingEntity = findDeploymentById(id);
         var domainObject = mapper.toDomain(existingEntity);
@@ -143,6 +143,11 @@ public class DeploymentRepository {
             log.debug("Deployment '{}' did not match condition, not updating", id);
             return false;
         }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)
+    public boolean conditionalUpdateInNewTransaction(String id, Predicate<Deployment> condition, Consumer<Deployment> mutator) {
+        return conditionalUpdate(id, condition, mutator);
     }
 
     public void deleteById(String id) {
@@ -161,6 +166,11 @@ public class DeploymentRepository {
     public void updateStatus(String id, DeploymentStatus status) {
         deploymentJpaRepository.updateStatus(id, PersistenceDeploymentStatus.valueOf(status.name()));
         log.debug("Status updated for deployment '{}' to: {}", id, status);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateStatusInNewTransaction(String id, DeploymentStatus status) {
+        updateStatus(id, status);
     }
 
     private void updateEntityFromDomain(DeploymentEntity entity, Deployment domain) {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -50,6 +50,7 @@ import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -265,7 +266,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                 return true;
             }
 
-            // If K8s status is RUNNING, extract URL and perform health checks
+            // If K8s status is RUNNING, extract URL and schedule health check after commit
             if (status == DeploymentStatus.RUNNING) {
                 // No need to look for deployments stuck in 'stopping' state because if stopping fails/hangs,
                 //   state will be changed to 'stopped' and the cleaner will pick it up on the next scheduled run
@@ -276,21 +277,17 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
 
                 var serviceName = getServiceName(deploymentId);
 
-                log.info("{}: deployment '{}' appears RUNNING in K8s (service '{}'), triggering readiness check to set URL",
+                log.info("{}: deployment '{}' appears RUNNING in K8s (service '{}'), scheduling readiness check after commit to set URL",
                         initiator, deploymentId, serviceName);
-                try {
-                    var serviceUrl = resolveServiceUrl(service, deployment);
-                    performHealthChecks(deployment, serviceUrl);
-                    deployment.setUrl(serviceUrl);
-                    deployment.setStatus(DeploymentStatus.RUNNING);
-                    deploymentRepository.update(deploymentId, deployment);
-                    log.info("{}: deployment '{}' marked RUNNING in DB after successful readiness check", initiator, deploymentId);
-                    return true;
-                } catch (Exception e) {
-                    deploymentRepository.updateStatus(deploymentId, DeploymentStatus.CRASHED);
-                    log.warn("{}: error during readiness check for deployment '{}'", initiator, deploymentId, e);
-                    return false;
-                }
+                var serviceUrl = resolveServiceUrl(service, deployment);
+
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        completeReconcileWithHealthCheck(deploymentId, serviceUrl, initiator);
+                    }
+                });
+                return true;
             }
 
             // For other statuses, just update the status
@@ -650,6 +647,28 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
 
     protected void performHealthChecks(D deployment, String serviceUrl) {
         // Default implementation does nothing
+    }
+
+    /**
+     * Runs after transaction commit: loads deployment and performs health checks (no transaction),
+     * then updates to RUNNING or CRASHED in a short write transaction (managed by repository class).
+     * This avoids holding a DB connection for the duration of health checks.
+     */
+    private void completeReconcileWithHealthCheck(String deploymentId, String serviceUrl, String initiator) {
+        D deployment = getDeployment(deploymentId);
+        try {
+            performHealthChecks(deployment, serviceUrl);
+            deploymentRepository.conditionalUpdate(deploymentId,
+                    Objects::nonNull,
+                    d -> {
+                        d.setUrl(serviceUrl);
+                        d.setStatus(DeploymentStatus.RUNNING);
+                    });
+            log.info("{}: deployment '{}' marked RUNNING in DB after successful readiness check", initiator, deploymentId);
+        } catch (Exception e) {
+            deploymentRepository.updateStatus(deploymentId, DeploymentStatus.CRASHED);
+            log.warn("{}: error during readiness check for deployment '{}'", initiator, deploymentId, e);
+        }
     }
 
     protected static <T extends EnvVar> List<T> filterEnvsByExactType(Deployment deployment, Class<T> type) {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -658,7 +658,8 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         D deployment = getDeployment(deploymentId);
         try {
             performHealthChecks(deployment, serviceUrl);
-            deploymentRepository.conditionalUpdate(deploymentId,
+            deploymentRepository.conditionalUpdateInNewTransaction(
+                    deploymentId,
                     Objects::nonNull,
                     d -> {
                         d.setUrl(serviceUrl);
@@ -666,7 +667,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                     });
             log.info("{}: deployment '{}' marked RUNNING in DB after successful readiness check", initiator, deploymentId);
         } catch (Exception e) {
-            deploymentRepository.updateStatus(deploymentId, DeploymentStatus.CRASHED);
+            deploymentRepository.updateStatusInNewTransaction(deploymentId, DeploymentStatus.CRASHED);
             log.warn("{}: error during readiness check for deployment '{}'", initiator, deploymentId, e);
         }
     }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
@@ -662,7 +662,7 @@ class InferenceDeploymentManagerTest {
 
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).conditionalUpdate(
+        verify(deploymentRepository).conditionalUpdateInNewTransaction(
                 eq(DEPLOYMENT_ID),
                 any(),
                 argThat(mutatorExpectingUrlAndRunning(SERVICE_URL)));
@@ -709,7 +709,7 @@ class InferenceDeploymentManagerTest {
 
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).conditionalUpdate(
+        verify(deploymentRepository).conditionalUpdateInNewTransaction(
                 eq(DEPLOYMENT_ID),
                 any(),
                 argThat(mutatorExpectingUrlAndRunning(INTERNAL_SERVICE_URL)));
@@ -789,7 +789,7 @@ class InferenceDeploymentManagerTest {
 
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).conditionalUpdate(
+        verify(deploymentRepository).conditionalUpdateInNewTransaction(
                 eq(DEPLOYMENT_ID),
                 any(),
                 argThat(mutatorExpectingUrlAndRunning(null)));
@@ -820,7 +820,7 @@ class InferenceDeploymentManagerTest {
 
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).conditionalUpdate(
+        verify(deploymentRepository).conditionalUpdateInNewTransaction(
                 eq(DEPLOYMENT_ID),
                 any(),
                 argThat(mutatorExpectingUrlAndRunning("")));

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -50,8 +51,10 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -654,12 +657,15 @@ class InferenceDeploymentManagerTest {
         // When
         boolean result = inferenceDeploymentManager.reconcile(reconcileConfig);
 
+        // Execute transaction synchronization callbacks manually for unit tests
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).update(eq(DEPLOYMENT_ID), argThat(updatedDeployment ->
-                updatedDeployment.getStatus() == DeploymentStatus.RUNNING
-                        && SERVICE_URL.equals(updatedDeployment.getUrl())
-        ));
+        verify(deploymentRepository).conditionalUpdate(
+                eq(DEPLOYMENT_ID),
+                any(),
+                argThat(mutatorExpectingUrlAndRunning(SERVICE_URL)));
     }
 
     @Test
@@ -698,12 +704,15 @@ class InferenceDeploymentManagerTest {
         // When
         boolean result = inferenceDeploymentManager.reconcile(reconcileConfig);
 
+        // Execute transaction synchronization callbacks manually for unit tests
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).update(eq(DEPLOYMENT_ID), argThat(updatedDeployment ->
-                updatedDeployment.getStatus() == DeploymentStatus.RUNNING
-                        && INTERNAL_SERVICE_URL.equals(updatedDeployment.getUrl())
-        ));
+        verify(deploymentRepository).conditionalUpdate(
+                eq(DEPLOYMENT_ID),
+                any(),
+                argThat(mutatorExpectingUrlAndRunning(INTERNAL_SERVICE_URL)));
     }
 
     @Test
@@ -775,12 +784,15 @@ class InferenceDeploymentManagerTest {
         // When
         boolean result = inferenceDeploymentManager.reconcile(reconcileConfig);
 
+        // Execute transaction synchronization callbacks manually for unit tests
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).update(eq(DEPLOYMENT_ID), argThat(updatedDeployment ->
-                updatedDeployment.getStatus() == DeploymentStatus.RUNNING
-                        && updatedDeployment.getUrl() == null
-        ));
+        verify(deploymentRepository).conditionalUpdate(
+                eq(DEPLOYMENT_ID),
+                any(),
+                argThat(mutatorExpectingUrlAndRunning(null)));
     }
 
     @Test
@@ -803,12 +815,15 @@ class InferenceDeploymentManagerTest {
         // When
         boolean result = inferenceDeploymentManager.reconcile(reconcileConfig);
 
+        // Execute transaction synchronization callbacks manually for unit tests
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
         // Then
         assertThat(result).isTrue();
-        verify(deploymentRepository).update(eq(DEPLOYMENT_ID), argThat(updatedDeployment ->
-                updatedDeployment.getStatus() == DeploymentStatus.RUNNING
-                        && "".equals(updatedDeployment.getUrl())
-        ));
+        verify(deploymentRepository).conditionalUpdate(
+                eq(DEPLOYMENT_ID),
+                any(),
+                argThat(mutatorExpectingUrlAndRunning("")));
     }
 
     @Test
@@ -831,6 +846,14 @@ class InferenceDeploymentManagerTest {
         // Then
         assertThat(result).isTrue();
         verify(deploymentRepository).updateStatus(eq(DEPLOYMENT_ID), eq(DeploymentStatus.STOPPING));
+    }
+
+    private ArgumentMatcher<Consumer<Deployment>> mutatorExpectingUrlAndRunning(String expectedUrl) {
+        return mutator -> {
+            Deployment d = createDeployment(DeploymentStatus.PENDING);
+            mutator.accept(d);
+            return d.getStatus() == DeploymentStatus.RUNNING && Objects.equals(expectedUrl, d.getUrl());
+        };
     }
 
     private Deployment createDeployment(DeploymentStatus status) {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- related to #22 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Refactored deployment status sync logic to perform health checks after transaction commit to avoid long-running transactions. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.