### PR TITLE
fix: return fresh deployment on rolling update

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -176,12 +176,12 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
 
     @Override
     @Transactional(isolation = Isolation.REPEATABLE_READ)
-    public void rollingUpdate(String id) {
+    public Deployment rollingUpdate(String id) {
         var deployment = getDeployment(id);
 
         if (deployment.getStatus() != DeploymentStatus.RUNNING) {
             log.info("Deployment '{}' is not running; skipping rolling update", id);
-            return;
+            return deployment;
         }
 
         try {
@@ -200,6 +200,9 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                     }
                 }
             });
+
+            deployment.setStatus(DeploymentStatus.PENDING);
+            return deployment;
 
         } catch (Exception e) {
             var errorMessage = "Rolling update failed for deployment '%s'".formatted(id);

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentManager.java
@@ -27,7 +27,7 @@ public interface DeploymentManager<S> {
 
     Deployment undeploy(String id);
 
-    void rollingUpdate(String id);
+    Deployment rollingUpdate(String id);
 
     void updateCiliumNetworkPolicy(String id);
 

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
@@ -182,6 +182,7 @@ public class DeploymentService {
         boolean isApplicableForRollingUpdate = isApplicableForRollingUpdate(existingDeploymentWithResolvedSecrets, updatedDeployment, envsAreChanged);
         if (updatedDeployment.getStatus() == DeploymentStatus.RUNNING && isApplicableForRollingUpdate) {
             deploymentManager.rollingUpdate(id);
+            updatedDeployment = deploymentRepository.getById(id).orElseThrow(notFound("Deployment", id));
         } else if (updatedDeployment.getStatus() == DeploymentStatus.CRASHED) {
             updatedDeployment = deploymentManager.undeploy(id);
         }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
@@ -181,8 +181,7 @@ public class DeploymentService {
 
         boolean isApplicableForRollingUpdate = isApplicableForRollingUpdate(existingDeploymentWithResolvedSecrets, updatedDeployment, envsAreChanged);
         if (updatedDeployment.getStatus() == DeploymentStatus.RUNNING && isApplicableForRollingUpdate) {
-            deploymentManager.rollingUpdate(id);
-            updatedDeployment = deploymentRepository.getById(id).orElseThrow(notFound("Deployment", id));
+            updatedDeployment = deploymentManager.rollingUpdate(id);
         } else if (updatedDeployment.getStatus() == DeploymentStatus.CRASHED) {
             updatedDeployment = deploymentManager.undeploy(id);
         }

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/DeploymentFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/DeploymentFunctionalTest.java
@@ -416,6 +416,7 @@ public abstract class DeploymentFunctionalTest {
         Assertions.assertEquals("updated-deployment", updatedDeployment.getDisplayName());
         Assertions.assertEquals(savedDeployment.getId(), updatedDeployment.getId());
         Assertions.assertEquals(newImageDefinitionId, updatedDeployment.getImageDefinitionId());
+        Assertions.assertEquals(DeploymentStatus.PENDING, updatedDeployment.getStatus());
 
         verify(resource, times(1)).update();
     }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #148 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Refactored 'rollingUpdate' to match with 'deploy' and 'undeploy' in terms of deployment status update & return pattern.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.