### PR TITLE
fix: ensure image build process uses specified base directory for context

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecification.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecification.java
@@ -151,7 +151,7 @@ public class ImageBuildFromGitJobSpecification extends ImageBuildAndPushJobSpeci
                 : WORKSPACE_PATH;
         var args = new ArrayList<>(List.of(
                 "--local",
-                "context=%s".formatted(WORKSPACE_PATH),
+                "context=%s".formatted(dockerfile),
                 "--local",
                 "dockerfile=%s".formatted(dockerfile)
         ));

--- a/src/test/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecificationTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecificationTest.java
@@ -221,7 +221,7 @@ class ImageBuildFromGitJobSpecificationTest {
         List<String> args = buildContainer.getArgs();
         assertNotNull(args);
         assertTrue(args.stream().anyMatch(arg -> arg.equals("dockerfile=/workspace/src/app")));
-        assertTrue(args.stream().anyMatch(arg -> arg.equals("context=/workspace")));
+        assertTrue(args.stream().anyMatch(arg -> arg.equals("context=/workspace/src/app")));
         assertFalse(args.stream().anyMatch(arg -> arg.equals("--no-push")));
     }
 
@@ -249,7 +249,7 @@ class ImageBuildFromGitJobSpecificationTest {
         Container buildContainer = getContainerByName(job, BUILDER_CONTAINER_NAME);
         List<String> args = buildContainer.getArgs();
 
-        assertThat(args).contains("context=/workspace");
+        assertThat(args).contains("context=/workspace/src/app");
         assertThat(args).contains("dockerfile=/workspace/src/app");
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- Ensures files are copied from the same directory as the Dockerfile, preventing build errors when the Dockerfile is located in a subfolder.

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.