### PR TITLE
chore: remove redundant stacktraces from logs

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentLogsService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentLogsService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.ExecutorService;
 
 @Slf4j
@@ -66,14 +67,19 @@ public class DeploymentLogsService {
                                             .name("logs")
                                             .data(line));
                                 } catch (IOException e) {
-                                    log.error("Failed to send log line. Deployment {}", id, e);
+                                    log.warn("Failed to send log line. Deployment {}", id, e);
                                     emitter.completeWithError(e);
                                 }
                             }
                         });
                 emitter.complete();
             } catch (Exception e) {
-                log.error("Failed to read logs for deployment {}", id, e);
+                String message = "Failed to read logs for deployment " + id;
+                if (e instanceof ClosedByInterruptException) {
+                    log.warn("{}. Reason: ClosedByInterruptException", message);
+                } else {
+                    log.warn(message, e);
+                }
                 emitter.completeWithError(e);
             }
         });

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/healthcheck/McpHealthChecker.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/healthcheck/McpHealthChecker.java
@@ -52,7 +52,7 @@ public class McpHealthChecker implements HealthChecker {
                 }
             });
         } catch (RuntimeException e) {
-            throw new IllegalStateException("MCP service failed to become ready at URL: " + serviceUrl, e);
+            throw new IllegalStateException("MCP service failed to become ready at URL: %s. Reason: %s".formatted(serviceUrl, e.getMessage()));
         }
         log.debug("MCP service is ready at URL: {}", serviceUrl);
     }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/healthcheck/McpHealthCheckerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/healthcheck/McpHealthCheckerTest.java
@@ -124,8 +124,7 @@ class McpHealthCheckerTest {
         );
 
         assertThat(exception)
-                .hasMessageContaining("MCP service failed to become ready at URL: " + SERVICE_URL)
-                .hasCause(initializationException);
+                .hasMessageContaining("MCP service failed to become ready at URL: %s. Reason: %s".formatted(SERVICE_URL, "Connection failed"));
         verify(retryTemplateFactory).apply(TIMEOUT);
         verify(mcpEndpointPathResolver).resolveEndpointPath(mcpDeployment);
     }


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
For unsuccessful health check, replaced stacktrace logging with error message only, since this scenario is frequent and trace is not useful. Also, removed full exception logging for failed logs streaming in case it was closed by interrupting.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.