### PR TITLE
feat: default allowed domains for huggingface inference deployments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,11 +242,12 @@ TLS and routing rules are generated automatically from `app.nim.deploy.cluster-h
 | `app.mcp-registry.base-url` | `MCP_REGISTRY_BASE_URL`  | `https://registry.modelcontextprotocol.io` | No       | -            | Base URL of the MCP Registry API (used by the proxy). |
 
 ### Hugging Face Configuration
-| Property                         | Environment Variable             | Default Value            | Required | Applied when | Description                                |
-|----------------------------------|----------------------------------|--------------------------|----------|--------------|--------------------------------------------|
-| `huggingface.base-url`           | `HUGGINGFACE_BASE_URL`           | `https://huggingface.co` | No       | -            | Base URL for Hugging Face API              |
-| `huggingface.api-token`          | `HUGGINGFACE_API_TOKEN`          | -                        | No       | -            | API token for authentication               |
-| `huggingface.tag-cache-duration` | `HUGGINGFACE_TAG_CACHE_DURATION` | `24h`                    | No       | -            | Duration to cache tag data (e.g. 24h, 60m) |
+| Property                                   | Environment Variable                   | Default Value                                                   | Required | Applied when | Description                                                                                                                      |
+|--------------------------------------------|----------------------------------------|-----------------------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `app.huggingface.base-url`                 | `HUGGINGFACE_BASE_URL`                 | `https://huggingface.co`                                        | No       | -            | Base URL for Hugging Face API                                                                                                    |
+| `app.huggingface.api-token`                | `HUGGINGFACE_API_TOKEN`                | -                                                               | No       | -            | API token for authentication                                                                                                     |
+| `app.huggingface.tag-cache-duration`       | `HUGGINGFACE_TAG_CACHE_DURATION`       | `24h`                                                           | No       | -            | Duration to cache tag data (e.g. 24h, 60m)                                                                                       |
+| `app.huggingface.default-allowed-domains`  | `HUGGINGFACE_DEFAULT_ALLOWED_DOMAINS`  | `huggingface.co,transfer.xethub.hf.co,cas-server.xethub.hf.co`  | No       | -            | Comma-separated list of default domains added to Cilium network policy egress for inference deployments with HuggingFace source. |
 
 ### Validation Configuration
 

--- a/src/main/java/com/epam/aidial/deployment/manager/huggingface/properties/HuggingFaceProperties.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/huggingface/properties/HuggingFaceProperties.java
@@ -1,18 +1,42 @@
 package com.epam.aidial.deployment.manager.huggingface.properties;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
 @Component
 @ConfigurationProperties(prefix = "app.huggingface")
 public class HuggingFaceProperties {
+
     private String baseUrl;
     private String apiToken;
     private Duration tagCacheDuration;
+
+    @Getter(AccessLevel.NONE)
+    private String defaultAllowedDomains;
+
+    /**
+     * Returns the default allowed domains for HuggingFace inference deployments egress.
+     * Parses the comma-separated string {@link #defaultAllowedDomains}.
+     */
+    public List<String> getDefaultAllowedDomains() {
+        if (StringUtils.isBlank(defaultAllowedDomains)) {
+            return new ArrayList<>();
+        }
+        return Arrays.stream(defaultAllowedDomains.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/huggingface/properties/HuggingFaceProperties.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/huggingface/properties/HuggingFaceProperties.java
@@ -8,10 +8,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.PostConstruct;
+
+import static java.util.stream.Collectors.toList;
 
 @Getter
 @Setter
@@ -26,17 +28,29 @@ public class HuggingFaceProperties {
     @Getter(AccessLevel.NONE)
     private String defaultAllowedDomains;
 
+    @Getter(AccessLevel.NONE)
+    private List<String> parsedDefaultAllowedDomains;
+
+    @PostConstruct
+    void initDefaultAllowedDomains() {
+        if (StringUtils.isBlank(defaultAllowedDomains)) {
+            parsedDefaultAllowedDomains = List.of();
+        } else {
+            parsedDefaultAllowedDomains = Stream.of(defaultAllowedDomains.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(toList());
+        }
+    }
+
     /**
      * Returns the default allowed domains for HuggingFace inference deployments egress.
-     * Parses the comma-separated string {@link #defaultAllowedDomains}.
+     * Parsed once at startup from the comma-separated {@link #defaultAllowedDomains} property.
+     * Null check is required for cases when method is called before init is done.
      */
     public List<String> getDefaultAllowedDomains() {
-        if (StringUtils.isBlank(defaultAllowedDomains)) {
-            return new ArrayList<>();
-        }
-        return Arrays.stream(defaultAllowedDomains.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.toList());
+        return parsedDefaultAllowedDomains == null
+                ? List.of()
+                : Collections.unmodifiableList(parsedDefaultAllowedDomains);
     }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -785,7 +785,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
     protected Set<Integer> getCiliumIngressPorts(D deployment) {
         Set<Integer> ports = new HashSet<>();
         Optional.ofNullable(deployment.getContainerPort()).ifPresent(ports::add);
-        Optional.of(defaultContainerPort).ifPresent(ports::add);
+        ports.add(defaultContainerPort);
         return ports;
     }
 

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -113,7 +113,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                 @Override
                 public void afterCommit() {
                     try {
-                        createCiliumNetworkPolicy(id, deployment.getAllowedDomains(), getCiliumIngressPorts(deployment));
+                        createCiliumNetworkPolicy(id, getEffectiveDeploymentAllowedDomains(deployment), getCiliumIngressPorts(deployment));
                         createService(namespace, serviceSpec);
                     } catch (Exception e) {
                         var errorMessage = "Failed to deploy service '%s'".formatted(id);
@@ -741,7 +741,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         var deployment = getDeployment(id);
 
         try {
-            updateCiliumNetworkPolicy(id, deployment.getAllowedDomains(), getCiliumIngressPorts(deployment));
+            updateCiliumNetworkPolicy(id, getEffectiveDeploymentAllowedDomains(deployment), getCiliumIngressPorts(deployment));
         } catch (Exception e) {
             var errorMessage = "Cilium Network Policy update failed for deployment '%s'".formatted(id);
             log.warn(errorMessage, e);
@@ -785,8 +785,13 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
     protected Set<Integer> getCiliumIngressPorts(D deployment) {
         Set<Integer> ports = new HashSet<>();
         Optional.ofNullable(deployment.getContainerPort()).ifPresent(ports::add);
-        Optional.ofNullable(defaultContainerPort).ifPresent(ports::add);
+        Optional.of(defaultContainerPort).ifPresent(ports::add);
         return ports;
+    }
+
+    protected List<String> getEffectiveDeploymentAllowedDomains(D deployment) {
+        var domains = deployment.getAllowedDomains();
+        return domains != null ? new ArrayList<>(domains) : new ArrayList<>();
     }
 
     private Map<String, String> transformEnvs(Map<String, EnvVarValue> envs) {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManager.java
@@ -25,7 +25,6 @@ import io.kserve.serving.v1beta1.inferenceservicestatus.ModelStatus;
 import io.kserve.serving.v1beta1.inferenceservicestatus.modelstatus.States;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -247,7 +246,7 @@ public class InferenceDeploymentManager extends AbstractModelDeploymentManager<I
 
         return Stream.concat(
                         allowedDomains.stream(),
-                        defaultAllowedDomains.stream().filter(StringUtils::isNotBlank))
+                        defaultAllowedDomains.stream())
                 .distinct()
                 .toList();
     }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManager.java
@@ -5,6 +5,7 @@ import com.epam.aidial.deployment.manager.cleanup.resource.model.DisposableResou
 import com.epam.aidial.deployment.manager.configuration.KserveDeployProperties;
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
 import com.epam.aidial.deployment.manager.dao.repository.DeploymentRepository;
+import com.epam.aidial.deployment.manager.huggingface.properties.HuggingFaceProperties;
 import com.epam.aidial.deployment.manager.kubernetes.K8sClient;
 import com.epam.aidial.deployment.manager.kubernetes.kserve.K8sKserveClient;
 import com.epam.aidial.deployment.manager.model.DeploymentStatus;
@@ -12,6 +13,7 @@ import com.epam.aidial.deployment.manager.model.SensitiveEnvVar;
 import com.epam.aidial.deployment.manager.model.SimpleEnvVar;
 import com.epam.aidial.deployment.manager.model.deployment.Deployment;
 import com.epam.aidial.deployment.manager.model.deployment.InferenceDeployment;
+import com.epam.aidial.deployment.manager.model.deployment.InferenceDeploymentHuggingFaceSource;
 import com.epam.aidial.deployment.manager.service.manifest.InferenceManifestGenerator;
 import com.epam.aidial.deployment.manager.service.manifest.ManifestGenerator;
 import com.epam.aidial.deployment.manager.service.pipeline.specification.CiliumNetworkPolicyCreator;
@@ -22,11 +24,14 @@ import io.kserve.serving.v1beta1.inferenceservicestatus.Components;
 import io.kserve.serving.v1beta1.inferenceservicestatus.ModelStatus;
 import io.kserve.serving.v1beta1.inferenceservicestatus.modelstatus.States;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Slf4j
 @Component
@@ -40,6 +45,7 @@ public class InferenceDeploymentManager extends AbstractModelDeploymentManager<I
     private final InferenceManifestGenerator inferenceManifestGenerator;
     private final K8sKserveClient k8sKserveClient;
     private final boolean useClusterInternalUrl;
+    private final List<String> defaultAllowedDomains;
 
     public InferenceDeploymentManager(
             K8sClient k8sClient,
@@ -50,7 +56,8 @@ public class InferenceDeploymentManager extends AbstractModelDeploymentManager<I
             CiliumNetworkPolicyCreator ciliumNetworkPolicyCreator,
             DeploymentRepository deploymentRepository,
             K8sKserveClient k8sKserveClient,
-            KserveDeployProperties kserveDeployProperties
+            KserveDeployProperties kserveDeployProperties,
+            HuggingFaceProperties huggingFaceProperties
     ) {
         super(k8sClient, disposableResourceManager, manifestGenerator, deploymentRepository,
                 containerPortResolver, ciliumNetworkPolicyCreator, kserveDeployProperties.getNamespace(),
@@ -58,6 +65,7 @@ public class InferenceDeploymentManager extends AbstractModelDeploymentManager<I
         this.inferenceManifestGenerator = inferenceManifestGenerator;
         this.k8sKserveClient = k8sKserveClient;
         this.useClusterInternalUrl = kserveDeployProperties.isUseClusterInternalUrl();
+        this.defaultAllowedDomains = huggingFaceProperties.getDefaultAllowedDomains();
     }
 
     @Override
@@ -226,6 +234,22 @@ public class InferenceDeploymentManager extends AbstractModelDeploymentManager<I
     @Override
     protected String getServiceNameLabel() {
         return SERVICE_NAME_LABEL;
+    }
+
+    @Override
+    protected List<String> getEffectiveDeploymentAllowedDomains(InferenceDeployment deployment) {
+        List<String> allowedDomains = super.getEffectiveDeploymentAllowedDomains(deployment);
+
+        if (!(deployment.getSource() instanceof InferenceDeploymentHuggingFaceSource)
+                || CollectionUtils.isEmpty(defaultAllowedDomains)) {
+            return allowedDomains;
+        }
+
+        return Stream.concat(
+                        allowedDomains.stream(),
+                        defaultAllowedDomains.stream().filter(StringUtils::isNotBlank))
+                .distinct()
+                .toList();
     }
 
     private String getClusterInternalUrl(Components predictor, String serviceName) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ app:
     base-url: ${HUGGINGFACE_BASE_URL:https://huggingface.co}
     api-token: ${HUGGINGFACE_API_TOKEN:}
     tag-cache-duration: ${HUGGINGFACE_TAG_CACHE_DURATION:24h}
+    default-allowed-domains: ${HUGGINGFACE_DEFAULT_ALLOWED_DOMAINS:huggingface.co,transfer.xethub.hf.co,cas-server.xethub.hf.co}
 
   mcp-registry:
     base-url: ${MCP_REGISTRY_BASE_URL:https://registry.modelcontextprotocol.io}

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/config/FunctionalTestConfiguration.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/config/FunctionalTestConfiguration.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
     "com.epam.aidial.deployment.manager.configuration",
     "com.epam.aidial.deployment.manager.dao",
     "com.epam.aidial.deployment.manager.docker",
+    "com.epam.aidial.deployment.manager.huggingface",
     "com.epam.aidial.deployment.manager.kubernetes",
     "com.epam.aidial.deployment.manager.mapper",
     "com.epam.aidial.deployment.manager.model",

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
@@ -49,6 +49,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -424,13 +425,24 @@ class InferenceDeploymentManagerTest {
         verify(disposableResourceManager).saveInferenceServiceResource(DEPLOYMENT_ID, NAMESPACE);
         verify(k8sKserveClient).createService(eq(NAMESPACE), eq(serviceSpec));
         verify(deploymentRepository).updateStatus(eq(DEPLOYMENT_ID), eq(DeploymentStatus.PENDING));
+
+        // Cilium policy created with deployment domains list (no default domains)
+        verify(ciliumNetworkPolicyCreator).create(
+                eq(NAMESPACE),
+                anyString(),
+                anyString(),
+                argThat((List<String> domains) ->
+                    domains.contains("test-domain-1")
+                        && domains.contains("test-domain-2")
+                        && domains.size() == 2),
+                any()
+        );
     }
 
     @Test
     void deploy_shouldMergeDefaultAllowedDomainsWithDeploymentDomainsForHuggingFaceSource() {
         // Given: HuggingFace source with deployment-specific domains and config default domains
-        var huggingFaceProperties = new HuggingFaceProperties();
-        huggingFaceProperties.setDefaultAllowedDomains("huggingface.co,cdn.huggingface.co");
+        var huggingFaceProperties = createHuggingFacePropertiesWithDefaultDomains();
         var managerWithDefaults = getInferenceDeploymentManager(huggingFaceProperties);
 
         InferenceDeployment deployment = (InferenceDeployment) createDeployment(DeploymentStatus.STOPPED);
@@ -462,6 +474,82 @@ class InferenceDeploymentManagerTest {
                                 && domains.contains("huggingface.co")
                                 && domains.contains("cdn.huggingface.co")
                                 && domains.size() == 3),
+                any()
+        );
+    }
+
+    @Test
+    void deploy_shouldNotAppendDefaultDomainsWhenSourceIsNotHuggingFace() {
+        // Given: non-HF source (e.g. S3) with config default domains set
+        var huggingFaceProperties = createHuggingFacePropertiesWithDefaultDomains();
+        var managerWithDefaults = getInferenceDeploymentManager(huggingFaceProperties);
+
+        Deployment deployment = createDeployment(DeploymentStatus.STOPPED);
+        // source is () -> "s3://test-bucket/model" — not InferenceDeploymentHuggingFaceSource
+        assertThat(((InferenceDeployment) deployment).getSource()).isNotInstanceOf(InferenceDeploymentHuggingFaceSource.class);
+
+        InferenceService serviceSpec = new InferenceService();
+        serviceSpec.setMetadata(new ObjectMeta());
+        serviceSpec.getMetadata().setName(SERVICE_NAME);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(containerPortResolver.resolveContainerPort(any(), eq(DEFAULT_KSERVE_SERVICE_PORT))).thenReturn(8080);
+        when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), any())).thenReturn(ciliumNetworkPolicy);
+        when(inferenceManifestGenerator.serviceConfig(eq(DEPLOYMENT_ID), any(), any(), any(), any(), any(), any(),
+                any(), any(), eq(8080), any())).thenReturn(serviceSpec);
+
+        // When
+        managerWithDefaults.deploy(DEPLOYMENT_ID);
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
+        // Then: only deployment allowedDomains are used; default domains are NOT appended
+        verify(ciliumNetworkPolicyCreator).create(
+                eq(NAMESPACE),
+                anyString(),
+                anyString(),
+                argThat((List<String> domains) ->
+                        domains.contains("test-domain-1")
+                                && domains.contains("test-domain-2")
+                                && domains.size() == 2),
+                any()
+        );
+    }
+
+    @Test
+    void deploy_shouldUseOnlyDefaultAllowedDomainsWhenDeploymentDomainsEmptyWithHuggingFaceSource() {
+        // Given: HuggingFace source with empty deployment allowedDomains
+        var huggingFaceProperties = createHuggingFacePropertiesWithDefaultDomains();
+        var managerWithDefaults = getInferenceDeploymentManager(huggingFaceProperties);
+
+        InferenceDeployment deployment = (InferenceDeployment) createDeployment(DeploymentStatus.STOPPED);
+        deployment.setSource(new InferenceDeploymentHuggingFaceSource("org/model"));
+        deployment.setAllowedDomains(Collections.emptyList());
+
+        InferenceService serviceSpec = new InferenceService();
+        serviceSpec.setMetadata(new ObjectMeta());
+        serviceSpec.getMetadata().setName(SERVICE_NAME);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(containerPortResolver.resolveContainerPort(any(), eq(DEFAULT_KSERVE_SERVICE_PORT))).thenReturn(8080);
+        when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), any())).thenReturn(ciliumNetworkPolicy);
+        when(inferenceManifestGenerator.serviceConfig(eq(DEPLOYMENT_ID), any(), any(), any(), any(), any(), any(),
+                any(), any(), eq(8080), any())).thenReturn(serviceSpec);
+
+        // When
+        managerWithDefaults.deploy(DEPLOYMENT_ID);
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
+        // Then: only default allowed domains appear in Cilium policy
+        verify(ciliumNetworkPolicyCreator).create(
+                eq(NAMESPACE),
+                anyString(),
+                anyString(),
+                argThat((List<String> domains) ->
+                        domains.contains("huggingface.co")
+                                && domains.contains("cdn.huggingface.co")
+                                && domains.size() == 2),
                 any()
         );
     }
@@ -1086,5 +1174,18 @@ class InferenceDeploymentManagerTest {
                 .initiator("Reconciliation Test")
                 .ignorePendingOnServiceNotFound(false)
                 .build();
+    }
+
+    private static HuggingFaceProperties createHuggingFacePropertiesWithDefaultDomains() {
+        var props = new HuggingFaceProperties();
+        props.setDefaultAllowedDomains("huggingface.co,cdn.huggingface.co");
+        try {
+            Method init = HuggingFaceProperties.class.getDeclaredMethod("initDefaultAllowedDomains");
+            init.setAccessible(true);
+            init.invoke(props);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return props;
     }
 }

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/InferenceDeploymentManagerTest.java
@@ -7,6 +7,7 @@ import com.epam.aidial.deployment.manager.dao.repository.DeploymentRepository;
 import com.epam.aidial.deployment.manager.exception.DeploymentException;
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
 import com.epam.aidial.deployment.manager.exception.ValidationException;
+import com.epam.aidial.deployment.manager.huggingface.properties.HuggingFaceProperties;
 import com.epam.aidial.deployment.manager.kubernetes.K8sClient;
 import com.epam.aidial.deployment.manager.kubernetes.kserve.K8sKserveClient;
 import com.epam.aidial.deployment.manager.model.DeploymentMetadata;
@@ -17,6 +18,7 @@ import com.epam.aidial.deployment.manager.model.SimpleEnvVar;
 import com.epam.aidial.deployment.manager.model.SimpleEnvVarValue;
 import com.epam.aidial.deployment.manager.model.deployment.Deployment;
 import com.epam.aidial.deployment.manager.model.deployment.InferenceDeployment;
+import com.epam.aidial.deployment.manager.model.deployment.InferenceDeploymentHuggingFaceSource;
 import com.epam.aidial.deployment.manager.service.manifest.InferenceManifestGenerator;
 import com.epam.aidial.deployment.manager.service.manifest.ManifestGenerator;
 import com.epam.aidial.deployment.manager.service.pipeline.specification.CiliumNetworkPolicyCreator;
@@ -115,6 +117,7 @@ class InferenceDeploymentManagerTest {
         kserveDeployProperties.setStartupTimeout(STARTUP_TIMEOUT);
         kserveDeployProperties.setUseClusterInternalUrl(false);
 
+        var huggingFaceProperties = new HuggingFaceProperties();
         inferenceDeploymentManager = new InferenceDeploymentManager(
                 k8sClient,
                 disposableResourceManager,
@@ -124,7 +127,8 @@ class InferenceDeploymentManagerTest {
                 ciliumNetworkPolicyCreator,
                 deploymentRepository,
                 k8sKserveClient,
-                kserveDeployProperties
+                kserveDeployProperties,
+                huggingFaceProperties
         );
 
         TransactionSynchronizationManager.initSynchronization();
@@ -423,6 +427,64 @@ class InferenceDeploymentManagerTest {
     }
 
     @Test
+    void deploy_shouldMergeDefaultAllowedDomainsWithDeploymentDomainsForHuggingFaceSource() {
+        // Given: HuggingFace source with deployment-specific domains and config default domains
+        var huggingFaceProperties = new HuggingFaceProperties();
+        huggingFaceProperties.setDefaultAllowedDomains("huggingface.co,cdn.huggingface.co");
+        var managerWithDefaults = getInferenceDeploymentManager(huggingFaceProperties);
+
+        InferenceDeployment deployment = (InferenceDeployment) createDeployment(DeploymentStatus.STOPPED);
+        deployment.setSource(new InferenceDeploymentHuggingFaceSource("org/model"));
+        deployment.setAllowedDomains(List.of("custom.com"));
+
+        InferenceService serviceSpec = new InferenceService();
+        serviceSpec.setMetadata(new ObjectMeta());
+        serviceSpec.getMetadata().setName(SERVICE_NAME);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(containerPortResolver.resolveContainerPort(any(), eq(DEFAULT_KSERVE_SERVICE_PORT))).thenReturn(8080);
+        when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), anyString(), anyList(), any())).thenReturn(ciliumNetworkPolicy);
+        when(inferenceManifestGenerator.serviceConfig(eq(DEPLOYMENT_ID), any(), any(), any(), any(), any(), any(),
+                any(), any(), eq(8080), any())).thenReturn(serviceSpec);
+
+        // When
+        managerWithDefaults.deploy(DEPLOYMENT_ID);
+        TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+
+        // Then: Cilium policy created with merged list (deployment domains + default domains, no duplicates)
+        verify(ciliumNetworkPolicyCreator).create(
+                eq(NAMESPACE),
+                anyString(),
+                anyString(),
+                argThat((List<String> domains) ->
+                        domains.contains("custom.com")
+                                && domains.contains("huggingface.co")
+                                && domains.contains("cdn.huggingface.co")
+                                && domains.size() == 3),
+                any()
+        );
+    }
+
+    private InferenceDeploymentManager getInferenceDeploymentManager(HuggingFaceProperties huggingFaceProperties) {
+        var kserveDeployProperties = new KserveDeployProperties();
+        kserveDeployProperties.setNamespace(NAMESPACE);
+        kserveDeployProperties.setStartupTimeout(STARTUP_TIMEOUT);
+        kserveDeployProperties.setUseClusterInternalUrl(false);
+        return new InferenceDeploymentManager(
+                k8sClient,
+                disposableResourceManager,
+                manifestGenerator,
+                inferenceManifestGenerator,
+                containerPortResolver,
+                ciliumNetworkPolicyCreator,
+                deploymentRepository,
+                k8sKserveClient,
+                kserveDeployProperties, huggingFaceProperties
+        );
+    }
+
+    @Test
     void deploy_shouldReturnExistingDeploymentIfAlreadyActive() {
         // Given
         Deployment deployment = createDeployment(DeploymentStatus.RUNNING);
@@ -687,6 +749,7 @@ class InferenceDeploymentManagerTest {
         kserveDeployProperties.setNamespace(NAMESPACE);
         kserveDeployProperties.setStartupTimeout(STARTUP_TIMEOUT);
         kserveDeployProperties.setUseClusterInternalUrl(true); // use internal url
+        var huggingFaceProperties = new HuggingFaceProperties();
         inferenceDeploymentManager = new InferenceDeploymentManager(
                 k8sClient,
                 disposableResourceManager,
@@ -696,7 +759,8 @@ class InferenceDeploymentManagerTest {
                 ciliumNetworkPolicyCreator,
                 deploymentRepository,
                 k8sKserveClient,
-                kserveDeployProperties
+                kserveDeployProperties,
+                huggingFaceProperties
         );
 
         var reconcileConfig = getReconcileConfig(service);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #188 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added new property 'app.huggingface.default-allowed-domains' to set domains which will be added to Cilium network policy egress by default for inference deployments with huggingface source.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.