### PR TITLE
fix: H2 migration to fix double-encoded deployment source JSON

### DIFF
--- a/src/main/java/db/migration/H2/V1_51__FixDoubleEncodedDeploymentSource.java
+++ b/src/main/java/db/migration/H2/V1_51__FixDoubleEncodedDeploymentSource.java
@@ -1,0 +1,45 @@
+package db.migration.H2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+@Slf4j
+public class V1_51__FixDoubleEncodedDeploymentSource extends BaseJavaMigration {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        log.info("Fixing double-encoded JSON in deployment.source");
+
+        String selectQuery = "SELECT id, CAST(source AS VARCHAR) AS source_text FROM deployment WHERE source IS NOT NULL";
+        String updateQuery = "UPDATE deployment SET source = ? FORMAT JSON WHERE id = ?";
+
+        try (Statement selectStmt = context.getConnection().createStatement();
+                PreparedStatement updateStmt = context.getConnection().prepareStatement(updateQuery);
+                ResultSet rs = selectStmt.executeQuery(selectQuery)) {
+
+            int count = 0;
+            while (rs.next()) {
+                String id = rs.getString("id");
+                String sourceText = rs.getString("source_text");
+                String unwrapped = MAPPER.readValue(sourceText, String.class);
+                updateStmt.setString(1, unwrapped);
+                updateStmt.setString(2, id);
+                updateStmt.addBatch();
+                count++;
+            }
+
+            if (count > 0) {
+                updateStmt.executeBatch();
+                log.info("Fixed {} double-encoded deployment source entries", count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes

V1.50 migration (`UnifyDeploymentSource`) used `CAST(? AS JSON)` with `setString()` in H2, which double-encoded the JSON — storing deployment source as a JSON string literal instead of a JSON object. This adds a V1.51 Java migration that unwraps the outer string encoding via Jackson and writes back proper JSON objects using `FORMAT JSON`. Only H2 is affected; Postgres and MS SQL handle the cast correctly.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.