### PR TITLE
fix: build privilege reset after saving an image

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/web/dto/ImageDefinitionRequestDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/dto/ImageDefinitionRequestDto.java
@@ -53,6 +53,6 @@ public abstract class ImageDefinitionRequestDto {
     @Nullable
     @ValidDomainList
     private List<String> allowedDomains = new ArrayList<>();
-    @Nullable
+    @NotNull
     private ImageBuilderDto imageBuilder;
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/web/dto/ImageDefinitionRequestDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/dto/ImageDefinitionRequestDto.java
@@ -54,5 +54,5 @@ public abstract class ImageDefinitionRequestDto {
     @ValidDomainList
     private List<String> allowedDomains = new ArrayList<>();
     @Nullable
-    private ImageBuilderDto imageBuilder = ImageBuilderDto.BUILDKIT_ROOTLESS;
+    private ImageBuilderDto imageBuilder;
 }

--- a/src/test/resources/mcp/definition/all_image_definitions.json
+++ b/src/test/resources/mcp/definition/all_image_definitions.json
@@ -17,6 +17,7 @@
     "imageName": "registry/echo-mcp:1.0.0",
     "builtAt": 1745996228431,
     "transportType": "local",
-    "allowedDomains": []
+    "allowedDomains": [],
+    "imageBuilder": "buildkit"
   }
 ]

--- a/src/test/resources/mcp/definition/create_image_definition_request.json
+++ b/src/test/resources/mcp/definition/create_image_definition_request.json
@@ -10,5 +10,6 @@
   "license": "MIT",
   "topics": ["test"],
   "transportType": "local",
-  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"]
+  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"],
+  "imageBuilder": "buildkit"
 }

--- a/src/test/resources/mcp/definition/create_image_definition_response.json
+++ b/src/test/resources/mcp/definition/create_image_definition_response.json
@@ -13,5 +13,6 @@
   "topics": ["test"],
   "buildStatus": "build_successful",
   "transportType": "local",
-  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"]
+  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"],
+  "imageBuilder": "buildkit"
 }

--- a/src/test/resources/mcp/definition/image_definition_by_id.json
+++ b/src/test/resources/mcp/definition/image_definition_by_id.json
@@ -16,5 +16,6 @@
   "imageName": "registry/echo-mcp:1.0.0",
   "builtAt": 1745996228431,
   "transportType": "local",
-  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"]
+  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"],
+  "imageBuilder": "buildkit"
 }

--- a/src/test/resources/mcp/definition/image_definition_by_id_response.json
+++ b/src/test/resources/mcp/definition/image_definition_by_id_response.json
@@ -13,5 +13,6 @@
   "topics": ["test"],
   "buildStatus": "build_successful",
   "transportType": "local",
-  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"]
+  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"],
+  "imageBuilder": "buildkit"
 }

--- a/src/test/resources/mcp/definition/update_image_definition_request.json
+++ b/src/test/resources/mcp/definition/update_image_definition_request.json
@@ -11,5 +11,6 @@
   "license": "MIT",
   "topics": ["test", "updated"],
   "transportType": "local",
-  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"]
+  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"],
+  "imageBuilder": "buildkit"
 }

--- a/src/test/resources/mcp/definition/update_image_definition_response.json
+++ b/src/test/resources/mcp/definition/update_image_definition_response.json
@@ -14,5 +14,6 @@
   "topics": ["test"],
   "buildStatus": "build_successful",
   "transportType": "local",
-  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"]
+  "allowedDomains": ["first-test-domain.com", "second-test-domain.io"],
+  "imageBuilder": "buildkit"
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #208 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Removed the default initialization of the `imageBuilder` field in the **ImageDefinitionRequestDto** class. Previously, imageBuilder was always set to `ImageBuilderDto.BUILDKIT_ROOTLESS`, which caused the system to ignore user-provided values (e.g., `ImageBuilderDto.BUILDKIT`) and always use the default. Now, `imageBuilder` is declared without a default value, allowing the system to correctly use the value provided by the user and preventing unintended overrides. This change resolves the issue where the wrong image builder was used and eliminates related errors.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.