### PR TITLE
hotfix: ensure image build process uses specified base directory for context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ COPY --chown=appuser:appuser docker-entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
+RUN apk add --no-cache zlib=1.3.2-r0 
+
 USER appuser
 
 EXPOSE 8080 9464

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     constraints {
-        implementation ('org.apache.tomcat.embed:tomcat-embed-core:11.0.14') {
+        implementation ('org.apache.tomcat.embed:tomcat-embed-core:11.0.18') {
             because("previous versions have vulnerabilities")
         }
         implementation ('com.nimbusds:nimbus-jose-jwt:10.3.1') {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecification.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecification.java
@@ -151,7 +151,7 @@ public class ImageBuildFromGitJobSpecification extends ImageBuildAndPushJobSpeci
                 : WORKSPACE_PATH;
         var args = new ArrayList<>(List.of(
                 "--local",
-                "context=%s".formatted(WORKSPACE_PATH),
+                "context=%s".formatted(dockerfile),
                 "--local",
                 "dockerfile=%s".formatted(dockerfile)
         ));

--- a/src/test/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecificationTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/pipeline/specification/ImageBuildFromGitJobSpecificationTest.java
@@ -221,7 +221,7 @@ class ImageBuildFromGitJobSpecificationTest {
         List<String> args = buildContainer.getArgs();
         assertNotNull(args);
         assertTrue(args.stream().anyMatch(arg -> arg.equals("dockerfile=/workspace/src/app")));
-        assertTrue(args.stream().anyMatch(arg -> arg.equals("context=/workspace")));
+        assertTrue(args.stream().anyMatch(arg -> arg.equals("context=/workspace/src/app")));
         assertFalse(args.stream().anyMatch(arg -> arg.equals("--no-push")));
     }
 
@@ -249,7 +249,7 @@ class ImageBuildFromGitJobSpecificationTest {
         Container buildContainer = getContainerByName(job, BUILDER_CONTAINER_NAME);
         List<String> args = buildContainer.getArgs();
 
-        assertThat(args).contains("context=/workspace");
+        assertThat(args).contains("context=/workspace/src/app");
         assertThat(args).contains("dockerfile=/workspace/src/app");
     }
 


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
Original PRs: 
- https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/178
- https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/201

Dependency fix:
- bump org.apache.tomcat.embed:tomcat-embed-core from 11.0.14 to 11.0.18

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.