### PR TITLE
fix: handle missing value for deployment env vars mounted as secure file

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
@@ -296,7 +296,7 @@ public class DeploymentService {
         });
 
         // Validate base64 encoding for sensitive file content
-        sensFile.forEach((key, value) -> validateBase64Encoding(key, value.getValue()));
+        sensFile.forEach(DeploymentService::validateBase64Encoding);
 
         // Return the original sensFile content for secret creation (not the _FILE suffix versions)
         return new EnvPartition(sens, nonSens, sensFile);
@@ -391,13 +391,13 @@ public class DeploymentService {
         }
     }
 
-    private static void validateBase64Encoding(String name, String value) {
-        if (value == null) {
+    private static void validateBase64Encoding(String name, EnvVarValue envVarValue) {
+        if (envVarValue == null || envVarValue.getValue() == null) {
             return;
         }
-        if (!isBase64Encoded(value)) {
+        if (!isBase64Encoded(envVarValue.getValue())) {
             throw new IllegalArgumentException("Env variable '%s' should contain base64-encoded file content. Actual content: %s"
-                    .formatted(name, value));
+                    .formatted(name, envVarValue.getValue()));
         }
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #215 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Add handling for missing value for deployment env vars mounted as secure file.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.