### PR TITLE
fix: MCP health check should pass if auth failed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-sqlserver:11.14.0'
     implementation 'com.google.cloud.sql:postgres-socket-factory:1.28.0'
 
-    implementation 'io.modelcontextprotocol.sdk:mcp:0.15.0'
+    implementation 'io.modelcontextprotocol.sdk:mcp:1.1.0'
     implementation 'com.google.cloud.tools:jib-core:0.27.3'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,9 @@ dependencies {
         implementation ('com.fasterxml.jackson.core:jackson-core:2.21.1') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('tools.jackson.core:jackson-core:3.1.0') {
+            because("previous versions have vulnerabilities")
+        }
         checkstyle ('org.apache.commons:commons-lang3:3.18.0') {
             because("previous versions have vulnerabilities")
         }

--- a/src/main/java/com/epam/aidial/deployment/manager/exception/McpClientException.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/exception/McpClientException.java
@@ -1,9 +1,15 @@
 package com.epam.aidial.deployment.manager.exception;
 
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
 /**
  * Exception thrown when MCP client operation fails.
  */
 public class McpClientException extends RuntimeException {
+
+    @Getter
+    private final HttpStatus httpStatus;
 
     /**
      * Creates a new McpClientException with the specified message and cause.
@@ -11,7 +17,8 @@ public class McpClientException extends RuntimeException {
      * @param message the error message
      * @param cause   the cause of the exception
      */
-    public McpClientException(String message, Throwable cause) {
+    public McpClientException(String message, HttpStatus httpStatus, Throwable cause) {
         super(message, cause);
+        this.httpStatus = httpStatus;
     }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/McpService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/McpService.java
@@ -7,13 +7,16 @@ import com.epam.aidial.deployment.manager.model.DeploymentStatus;
 import com.epam.aidial.deployment.manager.model.deployment.McpDeployment;
 import com.epam.aidial.deployment.manager.service.deployment.DeploymentService;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -57,9 +60,12 @@ public class McpService {
             var root = ExceptionUtils.getRootCause(e);
             String reason = root != null ? root.getMessage() : e.getMessage();
             String message = "Failed to %s MCP server. Deployment id: %s. Transport: '%s'. Path: '%s'"
-                    .formatted(operationName, deploymentId, deployment.getTransport(), deployment.getMcpEndpointPath());
+                    .formatted(operationName, deploymentId, deployment.getTransport(), Optional.ofNullable(deployment.getMcpEndpointPath()).orElse(""));
+            HttpStatus status = root instanceof McpHttpClientTransportAuthorizationException
+                    ? HttpStatus.UNAUTHORIZED
+                    : HttpStatus.INTERNAL_SERVER_ERROR;
             log.warn("{}. Reason: {}", message, reason);
-            throw new McpClientException(message, e);
+            throw new McpClientException(message, status, e);
         }
     }
 

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/healthcheck/McpHealthChecker.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/healthcheck/McpHealthChecker.java
@@ -5,8 +5,10 @@ import com.epam.aidial.deployment.manager.model.deployment.Deployment;
 import com.epam.aidial.deployment.manager.model.deployment.McpDeployment;
 import com.epam.aidial.deployment.manager.service.McpClientFactory;
 import com.epam.aidial.deployment.manager.service.McpEndpointPathResolver;
+import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
@@ -47,6 +49,12 @@ public class McpHealthChecker implements HealthChecker {
                     log.debug("MCP client initialized successfully for URL: {}", serviceUrl);
                     return null;
                 } catch (Exception e) {
+                    var root = ExceptionUtils.getRootCause(e);
+                    if (root instanceof McpHttpClientTransportAuthorizationException) {
+                        log.warn("MCP client initialization failed due to authorization exception. Marking MCP service as ready. URL: {}", serviceUrl);
+                        return null;
+                    }
+
                     log.debug("MCP client initialization failed for URL: {}, retrying...", serviceUrl, e);
                     throw new RuntimeException("MCP client initialization failed", e);
                 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/manifest/NimManifestGenerator.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/manifest/NimManifestGenerator.java
@@ -9,7 +9,6 @@ import com.epam.aidial.deployment.manager.model.probe.ProbeProperties;
 import com.epam.aidial.deployment.manager.utils.mapping.MappingChain;
 import com.epam.aidial.deployment.manager.utils.mapping.NimMappers;
 import com.google.cloud.tools.jib.api.ImageReference;
-import com.networknt.schema.utils.StringUtils;
 import com.nvidia.apps.v1alpha1.NIMService;
 import com.nvidia.apps.v1alpha1.NIMServiceSpec;
 import com.nvidia.apps.v1alpha1.nimservicespec.Env;
@@ -26,6 +25,7 @@ import com.nvidia.apps.v1alpha1.nimservicespec.expose.ingress.spec.rules.http.pa
 import io.fabric8.kubernetes.api.model.IntOrString;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
@@ -41,7 +41,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(McpClientException.class)
     public ErrorView handleMcpClientError(HttpServletRequest req, McpClientException ex) {
         logUncaught(ex);
-        return new ErrorView(req, HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return new ErrorView(req, ex.getHttpStatus(), ex.getMessage());
     }
 
     @ExceptionHandler(McpRegistryClientException.class)

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
@@ -18,7 +18,6 @@ import com.epam.aidial.deployment.manager.service.deployment.DeploymentService;
 import com.epam.aidial.deployment.manager.service.pipeline.specification.CiliumNetworkPolicyCreator;
 import com.epam.aidial.deployment.manager.utils.ResourceUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.networknt.schema.utils.StringUtils;
 import io.cilium.v2.CiliumNetworkPolicy;
 import io.fabric8.knative.client.KnativeClient;
 import io.fabric8.knative.serving.v1.RevisionSpec;
@@ -56,6 +55,7 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -182,7 +182,6 @@ public abstract class FullWorkflowWithMockedK8sClientFunctionalTest {
 
         // When - Create deployment
         var createdDeployment = deploymentService.createDeployment(deployment);
-        //deploymentRepository.updateServiceName(createdDeployment.getId(), K8sNamingUtils.generateName(createdDeployment.getId()));
 
         // Then - Create deployment
         var secret = secretCaptor.getValue();

--- a/src/test/java/com/epam/aidial/deployment/manager/service/McpServiceTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/McpServiceTest.java
@@ -9,6 +9,7 @@ import com.epam.aidial.deployment.manager.model.deployment.McpDeployment;
 import com.epam.aidial.deployment.manager.service.deployment.DeploymentService;
 import com.epam.aidial.deployment.manager.utils.TestException;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -179,6 +181,30 @@ class McpServiceTest {
         var exception = assertThrows(McpClientException.class, () -> mcpService.getTools(DEPLOYMENT_ID, NEXT_CURSOR));
 
         assertThat(exception).hasMessageContaining("Failed to connect to MCP server");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        verify(deploymentService).getDeployment(DEPLOYMENT_ID);
+        verify(mcpClientFactory).create(DEPLOYMENT_URL, endpointPath, McpTransport.SSE);
+        verify(mcpSyncClient).initialize();
+        verify(mcpSyncClient).close();
+    }
+
+    @Test
+    void testGetTools_clientClosedAfterUnauthorizedException() {
+        // Given
+        var deployment = createDeployment();
+        String endpointPath = "/sse";
+        deployment.setMcpEndpointPath(endpointPath);
+        deployment.setTransport(McpTransport.SSE);
+        when(deploymentService.getDeployment(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(mcpClientFactory.create(DEPLOYMENT_URL, endpointPath, McpTransport.SSE)).thenReturn(mcpSyncClient);
+        Mockito.doThrow(new McpHttpClientTransportAuthorizationException("Test exception", null)).when(mcpSyncClient).initialize();
+
+        // When/Then
+        var exception = assertThrows(McpClientException.class, () -> mcpService.getTools(DEPLOYMENT_ID, NEXT_CURSOR));
+
+        assertThat(exception).hasMessageContaining("Failed to connect to MCP server");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
 
         verify(deploymentService).getDeployment(DEPLOYMENT_ID);
         verify(mcpClientFactory).create(DEPLOYMENT_URL, endpointPath, McpTransport.SSE);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #227 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Updated version of io.modelcontextprotocol.sdk:mcp to 1.1.0
- Fixed MCP health check to pass if auth exception is thrown
- Support 'unauthorized' status code on failed MCP call (tools/resources/prompts)
- Added version constraint for tools.jackson.core:jackson-core:3.1.0

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.