### PR TITLE
fix: check image definition presence on create

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/exception/EntityAlreadyExistsException.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/exception/EntityAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.epam.aidial.deployment.manager.exception;
+
+public class EntityAlreadyExistsException extends RuntimeException {
+
+    public EntityAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/epam/aidial/deployment/manager/model/ImageType.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/model/ImageType.java
@@ -3,5 +3,14 @@ package com.epam.aidial.deployment.manager.model;
 public enum ImageType {
     MCP,
     ADAPTER,
-    INTERCEPTOR,
+    INTERCEPTOR;
+
+    public static ImageType of(ImageDefinition def) {
+        return switch (def) {
+            case McpImageDefinition ignored -> MCP;
+            case AdapterImageDefinition ignored -> ADAPTER;
+            case InterceptorImageDefinition ignored -> INTERCEPTOR;
+            default -> throw new IllegalArgumentException("Unsupported image definition type: " + def.getClass().getName());
+        };
+    }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/ImageDefinitionService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/ImageDefinitionService.java
@@ -3,6 +3,7 @@ package com.epam.aidial.deployment.manager.service;
 import com.epam.aidial.deployment.manager.cleanup.component.ComponentCleanupService;
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
 import com.epam.aidial.deployment.manager.dao.repository.ImageDefinitionRepository;
+import com.epam.aidial.deployment.manager.exception.EntityAlreadyExistsException;
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
 import com.epam.aidial.deployment.manager.model.ComponentRemoval;
 import com.epam.aidial.deployment.manager.model.ComponentType;
@@ -74,6 +75,16 @@ public class ImageDefinitionService {
 
     @Transactional
     public ImageDefinition createImageDefinition(ImageDefinition imageDefinition) {
+        var type = ImageType.of(imageDefinition);
+        var name = imageDefinition.getName();
+        var version = imageDefinition.getVersion();
+
+        imageDefinitionRepository.getImageDefinitionByTypeAndNameAndVersion(type, name, version)
+                .ifPresent(existing -> {
+                    throw new EntityAlreadyExistsException(
+                            "Image definition already exists: type=%s, name=%s, version=%s".formatted(type, name, version));
+                });
+
         imageDefinition.setBuildStatus(ImageStatus.NOT_BUILT);
 
         // Set author information - use provided author or extract from security context

--- a/src/main/java/com/epam/aidial/deployment/manager/service/config/imports/DeploymentImporter.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/config/imports/DeploymentImporter.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.deployment.manager.service.config.imports;
 
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
+import com.epam.aidial.deployment.manager.exception.EntityAlreadyExistsException;
 import com.epam.aidial.deployment.manager.mapper.DeploymentMapper;
 import com.epam.aidial.deployment.manager.model.ConflictResolutionPolicy;
 import com.epam.aidial.deployment.manager.model.config.ExportConfig;
@@ -45,7 +46,7 @@ public class DeploymentImporter {
 
         if (existing.isPresent()) {
             switch (policy) {
-                case FAIL_IF_EXISTS -> throw new IllegalStateException("Deployment already exists: " + id);
+                case FAIL_IF_EXISTS -> throw new EntityAlreadyExistsException("Deployment already exists: " + id);
                 case SKIP_IF_EXISTS -> log.debug("Skipping existing deployment: {}", id);
                 case OVERWRITE -> {
                     CreateDeployment createRequest = deploymentMapper.toCreateDeployment(imported);

--- a/src/main/java/com/epam/aidial/deployment/manager/service/config/imports/ImageDefinitionImporter.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/config/imports/ImageDefinitionImporter.java
@@ -1,12 +1,10 @@
 package com.epam.aidial.deployment.manager.service.config.imports;
 
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
-import com.epam.aidial.deployment.manager.model.AdapterImageDefinition;
+import com.epam.aidial.deployment.manager.exception.EntityAlreadyExistsException;
 import com.epam.aidial.deployment.manager.model.ConflictResolutionPolicy;
 import com.epam.aidial.deployment.manager.model.ImageDefinition;
 import com.epam.aidial.deployment.manager.model.ImageType;
-import com.epam.aidial.deployment.manager.model.InterceptorImageDefinition;
-import com.epam.aidial.deployment.manager.model.McpImageDefinition;
 import com.epam.aidial.deployment.manager.model.config.ExportConfig;
 import com.epam.aidial.deployment.manager.service.ImageDefinitionService;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -46,13 +44,13 @@ public class ImageDefinitionImporter {
     private void importOne(ImageDefinition imported, ConflictResolutionPolicy policy) {
         String name = imported.getName();
         String version = imported.getVersion();
-        ImageType type = imageTypeOf(imported);
+        ImageType type = ImageType.of(imported);
 
         Optional<ImageDefinition> existing = imageDefinitionService.getImageDefinitionByTypeAndNameAndVersion(type, name, version);
 
         if (existing.isPresent()) {
             switch (policy) {
-                case FAIL_IF_EXISTS -> throw new IllegalStateException(
+                case FAIL_IF_EXISTS -> throw new EntityAlreadyExistsException(
                         "Image definition already exists: type=%s, name=%s, version=%s".formatted(type, name, version));
                 case SKIP_IF_EXISTS -> log.debug("Skipping existing image definition: type={}, name={}, version={}", type, name, version);
                 case OVERWRITE -> {
@@ -67,15 +65,6 @@ public class ImageDefinitionImporter {
             imageDefinitionService.createImageDefinition(toCreate);
             log.debug("Created image definition: type={}, name={}, version={}", type, name, version);
         }
-    }
-
-    private static ImageType imageTypeOf(ImageDefinition def) {
-        return switch (def) {
-            case McpImageDefinition ignored -> ImageType.MCP;
-            case AdapterImageDefinition ignored -> ImageType.ADAPTER;
-            case InterceptorImageDefinition ignored -> ImageType.INTERCEPTOR;
-            default -> throw new IllegalArgumentException("Unsupported image definition type: " + def.getClass().getName());
-        };
     }
 
     private ImageDefinition mergeForOverwrite(ImageDefinition imported, ImageDefinition existing) {

--- a/src/main/java/com/epam/aidial/deployment/manager/service/config/previews/ImageDefinitionImportPreviewer.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/config/previews/ImageDefinitionImportPreviewer.java
@@ -1,12 +1,9 @@
 package com.epam.aidial.deployment.manager.service.config.previews;
 
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
-import com.epam.aidial.deployment.manager.model.AdapterImageDefinition;
 import com.epam.aidial.deployment.manager.model.ConflictResolutionPolicy;
 import com.epam.aidial.deployment.manager.model.ImageDefinition;
 import com.epam.aidial.deployment.manager.model.ImageType;
-import com.epam.aidial.deployment.manager.model.InterceptorImageDefinition;
-import com.epam.aidial.deployment.manager.model.McpImageDefinition;
 import com.epam.aidial.deployment.manager.model.config.ExportConfig;
 import com.epam.aidial.deployment.manager.model.config.ImportAction;
 import com.epam.aidial.deployment.manager.model.config.ImportComponent;
@@ -66,7 +63,7 @@ public class ImageDefinitionImportPreviewer {
     private <T extends ImageDefinition> ImportComponent<T> previewOne(T imported, ConflictResolutionPolicy policy) {
         String name = imported.getName();
         String version = imported.getVersion();
-        ImageType type = imageTypeOf(imported);
+        ImageType type = ImageType.of(imported);
 
         Optional<ImageDefinition> existingOpt = imageDefinitionService.getImageDefinitionByTypeAndNameAndVersion(type, name, version);
 
@@ -82,12 +79,4 @@ public class ImageDefinitionImportPreviewer {
         };
     }
 
-    private static ImageType imageTypeOf(ImageDefinition def) {
-        return switch (def) {
-            case McpImageDefinition ignored -> ImageType.MCP;
-            case AdapterImageDefinition ignored -> ImageType.ADAPTER;
-            case InterceptorImageDefinition ignored -> ImageType.INTERCEPTOR;
-            default -> throw new IllegalArgumentException("Unsupported image definition type: " + def.getClass().getName());
-        };
-    }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/DeploymentService.java
@@ -7,7 +7,6 @@ import com.epam.aidial.deployment.manager.dao.repository.DeploymentRepository;
 import com.epam.aidial.deployment.manager.exception.DeploymentException;
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
 import com.epam.aidial.deployment.manager.mapper.DeploymentMapper;
-import com.epam.aidial.deployment.manager.model.AdapterImageDefinition;
 import com.epam.aidial.deployment.manager.model.ComponentRemoval;
 import com.epam.aidial.deployment.manager.model.ComponentType;
 import com.epam.aidial.deployment.manager.model.DeploymentMetadata;
@@ -18,8 +17,6 @@ import com.epam.aidial.deployment.manager.model.EnvVarValue;
 import com.epam.aidial.deployment.manager.model.ImageDefinition;
 import com.epam.aidial.deployment.manager.model.ImageStatus;
 import com.epam.aidial.deployment.manager.model.ImageType;
-import com.epam.aidial.deployment.manager.model.InterceptorImageDefinition;
-import com.epam.aidial.deployment.manager.model.McpImageDefinition;
 import com.epam.aidial.deployment.manager.model.PodInfo;
 import com.epam.aidial.deployment.manager.model.SimpleEnvVar;
 import com.epam.aidial.deployment.manager.model.deployment.CreateDeployment;
@@ -232,7 +229,7 @@ public class DeploymentService {
     @Transactional
     public void updateImageDefinitionForDeployments(UUID imageDefinitionId, List<String> deployments) {
         var imageDefinition = loadImageDefinitionOrThrow(imageDefinitionId);
-        var imageType = getImageDefinitionType(imageDefinition);
+        var imageType = ImageType.of(imageDefinition);
         deploymentRepository.updateImageDefinitionForDeployments(imageDefinition, imageType, deployments);
         deployments.forEach(this::rollingUpdate);
     }
@@ -340,19 +337,10 @@ public class DeploymentService {
     private void setDeploymentImageDefinitionRef(Deployment deployment, ImageDefinition imageDefinition) {
         deployment.setSource(new InternalImageSource(
                 imageDefinition.getId(),
-                getImageDefinitionType(imageDefinition),
+                ImageType.of(imageDefinition),
                 imageDefinition.getName(),
                 imageDefinition.getVersion()
         ));
-    }
-
-    private static ImageType getImageDefinitionType(ImageDefinition imageDefinition) {
-        return switch (imageDefinition) {
-            case McpImageDefinition ignored -> ImageType.MCP;
-            case AdapterImageDefinition ignored -> ImageType.ADAPTER;
-            case InterceptorImageDefinition ignored -> ImageType.INTERCEPTOR;
-            default -> throw new IllegalArgumentException("Unknown image definition type: " + imageDefinition.getClass().getName());
-        };
     }
 
     private ImageDefinition loadImageDefinitionOrThrow(UUID id) {

--- a/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/handler/DefaultExceptionHandler.java
@@ -3,6 +3,7 @@ package com.epam.aidial.deployment.manager.web.handler;
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
 import com.epam.aidial.deployment.manager.exception.DatabaseException;
 import com.epam.aidial.deployment.manager.exception.DeploymentException;
+import com.epam.aidial.deployment.manager.exception.EntityAlreadyExistsException;
 import com.epam.aidial.deployment.manager.exception.EntityNotFoundException;
 import com.epam.aidial.deployment.manager.exception.ImageInUseException;
 import com.epam.aidial.deployment.manager.exception.McpClientException;
@@ -137,6 +138,13 @@ public class DefaultExceptionHandler {
     public ErrorView handleIllegalArgumentError(HttpServletRequest req, Exception ex) {
         logUncaught(ex);
         return new ErrorView(req, HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(EntityAlreadyExistsException.class)
+    public ErrorView handleEntityAlreadyExistsException(HttpServletRequest req, EntityAlreadyExistsException ex) {
+        logUncaught(ex);
+        return new ErrorView(req, HttpStatus.CONFLICT, ex.getMessage());
     }
 
     @ResponseStatus(HttpStatus.CONFLICT)

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/ConfigExportImportFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/ConfigExportImportFunctionalTest.java
@@ -3,7 +3,6 @@ package com.epam.aidial.deployment.manager.functional.tests;
 import com.epam.aidial.deployment.manager.configuration.ConfigExportProperties;
 import com.epam.aidial.deployment.manager.functional.utils.FunctionalTestHelper;
 import com.epam.aidial.deployment.manager.mapper.DeploymentMapper;
-import com.epam.aidial.deployment.manager.model.AdapterImageDefinition;
 import com.epam.aidial.deployment.manager.model.ConflictResolutionPolicy;
 import com.epam.aidial.deployment.manager.model.DeploymentMetadata;
 import com.epam.aidial.deployment.manager.model.DockerImageSource;
@@ -14,7 +13,6 @@ import com.epam.aidial.deployment.manager.model.ImageBuilder;
 import com.epam.aidial.deployment.manager.model.ImageDefinition;
 import com.epam.aidial.deployment.manager.model.ImageSource;
 import com.epam.aidial.deployment.manager.model.ImageType;
-import com.epam.aidial.deployment.manager.model.InterceptorImageDefinition;
 import com.epam.aidial.deployment.manager.model.McpImageDefinition;
 import com.epam.aidial.deployment.manager.model.McpRegistryRef;
 import com.epam.aidial.deployment.manager.model.McpTransport;
@@ -221,7 +219,7 @@ public abstract class ConfigExportImportFunctionalTest {
         var expectedImageDefs = buildExportImageDefinitions();
         for (var expected : expectedImageDefs) {
             var actual = imageDefinitionService.getImageDefinitionByTypeAndNameAndVersion(
-                    imageTypeOf(expected), expected.getName(), expected.getVersion()).orElseThrow();
+                    ImageType.of(expected), expected.getName(), expected.getVersion()).orElseThrow();
             assertImageDefinitionEquals(actual, expected);
         }
 
@@ -470,15 +468,6 @@ public abstract class ConfigExportImportFunctionalTest {
         return buildExportDeployments().stream()
                 .map(deploymentMapper::toDeployment)
                 .toList();
-    }
-
-    private static ImageType imageTypeOf(ImageDefinition def) {
-        return switch (def) {
-            case McpImageDefinition ignored -> ImageType.MCP;
-            case AdapterImageDefinition ignored -> ImageType.ADAPTER;
-            case InterceptorImageDefinition ignored -> ImageType.INTERCEPTOR;
-            default -> throw new IllegalArgumentException("Unsupported: " + def.getClass().getName());
-        };
     }
 
     private static DeploymentMetadata mcpDeploymentMetadata() {

--- a/src/test/java/com/epam/aidial/deployment/manager/service/config/imports/DeploymentImporterTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/config/imports/DeploymentImporterTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.deployment.manager.service.config.imports;
 
+import com.epam.aidial.deployment.manager.exception.EntityAlreadyExistsException;
 import com.epam.aidial.deployment.manager.mapper.DeploymentMapper;
 import com.epam.aidial.deployment.manager.model.ConflictResolutionPolicy;
 import com.epam.aidial.deployment.manager.model.McpTransport;
@@ -77,7 +78,7 @@ class DeploymentImporterTest {
         when(deploymentService.getDeployment(DEPLOYMENT_ID, false)).thenReturn(Optional.of(imported));
 
         assertThatThrownBy(() -> deploymentImporter.importDeployments(config, ConflictResolutionPolicy.FAIL_IF_EXISTS))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(EntityAlreadyExistsException.class)
                 .hasMessageContaining("already exists")
                 .hasMessageContaining(DEPLOYMENT_ID);
 

--- a/src/test/java/com/epam/aidial/deployment/manager/service/config/imports/ImageDefinitionImporterTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/config/imports/ImageDefinitionImporterTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.deployment.manager.service.config.imports;
 
 import com.epam.aidial.deployment.manager.configuration.JsonMapperConfiguration;
 import com.epam.aidial.deployment.manager.configuration.export.ImageDefinitionExportMixIn;
+import com.epam.aidial.deployment.manager.exception.EntityAlreadyExistsException;
 import com.epam.aidial.deployment.manager.model.AdapterImageDefinition;
 import com.epam.aidial.deployment.manager.model.ConflictResolutionPolicy;
 import com.epam.aidial.deployment.manager.model.ImageDefinition;
@@ -98,7 +99,7 @@ class ImageDefinitionImporterTest {
                 .thenReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> imageDefinitionImporter.importImageDefinitions(config, ConflictResolutionPolicy.FAIL_IF_EXISTS))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(EntityAlreadyExistsException.class)
                 .hasMessageContaining("already exists")
                 .hasMessageContaining(NAME)
                 .hasMessageContaining(VERSION);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #218 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added check for existing image definition on create to handle exception earlier and display user-friendly error message. Unified image definition type detection.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.