### PR TITLE
fix: redundant signal-specific traces, metrics, and logs endpoint/protocol overrides

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -449,15 +449,6 @@ otel:
     otlp:
       endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
       protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL}
-      traces:
-        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
-        protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL}
-      metrics:
-        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
-        protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL}
-      logs:
-        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
-        protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL}
   logs:
     exporter: ${OTEL_LOGS_EXPORTER:otlp}
   traces:


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #239 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Removed the redundant signal-specific traces, metrics, and logs endpoint/protocol overrides from application.yml. The base `otel.exporter.otlp.endpoint` and `otel.exporter.otlp.protocol` are sufficient — the SDK will auto-append /v1/traces, /v1/metrics, /v1/logs when using http/protobuf. For grpc, this change is a no-op (gRPC doesn't use URL paths).
Reference: https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.