### PR TITLE
fix: allow tool calling for full admins only

### DIFF
--- a/specs/008-read-only-role/contracts/authorization.md
+++ b/specs/008-read-only-role/contracts/authorization.md
@@ -48,6 +48,12 @@ All endpoints below return **403 Forbidden** for READ_ONLY_ADMIN users. FULL_ADM
 |---|---|---|
 | POST | `/image-build` | updateDomainWhitelistForImageBuild |
 
+### McpController (`/api/v1/deployments/mcp`)
+
+| Method | Path | Operation |
+|---|---|---|
+| POST | `/{deploymentId}/call-tool` | callTool |
+
 ## Endpoints NOT annotated (read-only, accessible to all authenticated users)
 
 - All GET endpoints across all controllers

--- a/specs/mcp-servers/spec.md
+++ b/specs/mcp-servers/spec.md
@@ -50,13 +50,17 @@ Status: **Implemented**
 - **THEN** the list of prompts advertised by the MCP server is returned
 
 ### Requirement: Call an MCP tool on a deployment
-The system SHALL invoke a specific tool on a live MCP deployment and return the result.
+The system SHALL invoke a specific tool on a live MCP deployment and return the result. This endpoint is protected by `@FullAdminOnly` — only FULL_ADMIN users may call tools; READ_ONLY_ADMIN users receive 403.
 
 Status: **Implemented**
 
 #### Scenario: Successful tool call
-- **WHEN** `POST /api/v1/deployments/mcp/{deploymentId}/call-tool` is called with a valid tool name and arguments
+- **WHEN** `POST /api/v1/deployments/mcp/{deploymentId}/call-tool` is called by a FULL_ADMIN user with a valid tool name and arguments
 - **THEN** the tool is invoked on the MCP server and the result is returned
+
+#### Scenario: Read-only admin attempts tool call
+- **WHEN** `POST /api/v1/deployments/mcp/{deploymentId}/call-tool` is called by a READ_ONLY_ADMIN user
+- **THEN** the system responds with 403 Forbidden
 
 #### Scenario: MCP server unreachable during tool call
 - **WHEN** `POST /api/v1/deployments/mcp/{deploymentId}/call-tool` is called and the MCP server is unavailable

--- a/specs/security/spec.md
+++ b/specs/security/spec.md
@@ -164,6 +164,7 @@ Status: **Implemented**
 | ImageBuildController | POST | `/api/v1/images/builds` | buildImage |
 | DisposableResourceController | POST | `/api/v1/disposable/clean` | clean |
 | GlobalDomainWhitelistController | POST | `/api/v1/global-whitelist/image-build` | updateDomainWhitelistForImageBuild |
+| McpController | POST | `/api/v1/deployments/mcp/{deploymentId}/call-tool` | callTool |
 
 ## Implementation Notes
 - Security configurations: `OidcSecurityConfiguration` (oidc), `BasicSecurityConfiguration` (basic), `NoneSecurityConfiguration` (none)

--- a/src/main/java/com/epam/aidial/deployment/manager/web/controller/McpController.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/controller/McpController.java
@@ -2,6 +2,7 @@ package com.epam.aidial.deployment.manager.web.controller;
 
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
 import com.epam.aidial.deployment.manager.service.McpService;
+import com.epam.aidial.deployment.manager.web.security.FullAdminOnly;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -29,6 +30,7 @@ public class McpController {
         return mcpService.getTools(deploymentId, nextCursor);
     }
 
+    @FullAdminOnly
     @PostMapping(path = "/{deploymentId}/call-tool", produces = MediaType.APPLICATION_JSON_VALUE)
     public McpSchema.CallToolResult callTool(@PathVariable String deploymentId,
                                              @RequestBody McpSchema.CallToolRequest callToolRequest) {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #149 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Made changes to make endpoint 'POST /api/v1/deployments/mcp/{deploymentId}/call-tool' available only for users with full admin permissions.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.