### PR TITLE
chore: force secure dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ dependencies {
         implementation ('io.netty:netty-codec-http:4.2.10.Final') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('org.springframework:spring-webmvc:6.2.10') {
+        implementation ('org.springframework:spring-webmvc:6.2.17') {
             because("previous versions have vulnerabilities")
         }
         implementation ('org.springframework.security:spring-security-core:6.5.4') {
@@ -183,7 +183,10 @@ dependencies {
         implementation ('com.fasterxml.jackson.core:jackson-core:2.21.1') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('tools.jackson.core:jackson-core:3.1.0') {
+        implementation ('tools.jackson.core:jackson-core:3.1.1') {
+            because("previous versions have vulnerabilities")
+        }
+        checkstyle ('org.codehaus.plexus:plexus-utils:4.0.3') {
             because("previous versions have vulnerabilities")
         }
         checkstyle ('org.apache.commons:commons-lang3:3.18.0') {


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->

- 'org.springframework:spring-webmvc' 6.2.10 -> 6.2.17
- 'tools.jackson.core:jackson-core' 3.1.0 -> 3.1.1
- forced 'org.codehaus.plexus:plexus-utils:4.0.3'

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.