### PR TITLE
feat: add packageTransportTypes filter and rename remoteTypes to remo…

### DIFF
--- a/specs/009-mcp-registry-filtering/contracts/api.md
+++ b/specs/009-mcp-registry-filtering/contracts/api.md
@@ -6,27 +6,30 @@
 
 List MCP servers with optional backend filtering.
 
-**New query parameters** (all optional, added alongside existing params):
+**Filter query parameters** (all optional):
 
-| Parameter              | Type            | Required | Description                                                                 |
-|------------------------|-----------------|----------|-----------------------------------------------------------------------------|
-| `remoteTypes`          | String (CSV)    | No       | Comma-separated remote transport types. Values: `sse`, `streamable-http`.   |
-| `packageRegistryTypes` | String (CSV)    | No       | Comma-separated package registry types. Values: `npm`, `pypi`, `oci`, `nuget`, `mcpb`. |
-| `repositoryExists`     | Boolean         | No       | `true` = only servers with repository; `false` = only servers without.      |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `remoteTransportTypes` | `List<String>` (repeated param) | No | Remote transport types (OR logic). Values: `sse`, `streamable-http`. **Renamed from `remoteTypes`.** |
+| `packageRegistryTypes` | `List<String>` (repeated param) | No | Package registry types (OR logic). Values: `npm`, `pypi`, `oci`, `nuget`, `mcpb`. |
+| `packageTransportTypes` | `List<String>` (repeated param) | No | **New.** Package transport types (OR logic). Values: `stdio`, `streamable-http`, `sse`. |
+| `repositoryExists` | `Boolean` | No | `true` = only servers with repository; `false` = only servers without. |
+
+Multi-value encoding: repeat the parameter name — `remoteTransportTypes=sse&remoteTransportTypes=streamable-http`.
 
 **Existing parameters** (unchanged):
 
-| Parameter     | Type    | Required | Description                              |
-|---------------|---------|----------|------------------------------------------|
-| `cursor`      | String  | No       | Pagination cursor                        |
-| `limit`       | Integer | No       | Max items (1-1000, default 100)          |
-| `search`      | String  | No       | Name search (forwarded to upstream)      |
-| `updatedSince`| String  | No       | RFC3339 timestamp (forwarded to upstream)|
-| `version`     | String  | No       | Version filter (forwarded to upstream)   |
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cursor` | String | Pagination cursor |
+| `limit` | Integer | Max items (1–1000, default 100) |
+| `search` | String | Name search (forwarded to upstream) |
+| `updatedSince` | String | RFC3339 timestamp (forwarded to upstream) |
+| `version` | String | Version filter (forwarded to upstream) |
 
 **Example**:
 ```
-GET /api/v1/mcp-registry/servers?remoteTypes=sse,streamable-http&packageRegistryTypes=npm&repositoryExists=true&limit=20
+GET /api/v1/mcp-registry/servers?remoteTransportTypes=sse&packageRegistryTypes=oci&packageTransportTypes=streamable-http&repositoryExists=true&limit=20
 ```
 
 **Response**: `ServerListResponseDto` (unchanged shape)
@@ -40,11 +43,13 @@ GET /api/v1/mcp-registry/servers?remoteTypes=sse,streamable-http&packageRegistry
 }
 ```
 
+---
+
 ### POST /api/v1/mcp-registry/servers/list
 
 List MCP servers with optional backend filtering (POST variant).
 
-**Modified request body** (`ServersRequestDto`):
+**Request body** (`ServersRequestDto`):
 
 ```json
 {
@@ -54,57 +59,57 @@ List MCP servers with optional backend filtering (POST variant).
   "updatedSince": null,
   "version": "latest",
   "filter": {
-    "remoteTypes": ["sse", "streamable-http"],
+    "remoteTransportTypes": ["sse", "streamable-http"],
     "packageRegistryTypes": ["npm", "oci"],
+    "packageTransportTypes": ["stdio"],
     "repositoryExists": true
   }
 }
 ```
 
-**New field**:
+**`ServerFilterDto` schema** (within `filter`):
 
-| Field    | Type             | Required | Description                                                                          |
-|----------|------------------|----------|--------------------------------------------------------------------------------------|
-| `filter` | `ServerFilterDto`| No       | When absent/null, pass-through behavior. When present, backend filtering is applied. |
-
-**`ServerFilterDto` schema**:
-
-| Field                  | Type             | Required | Description                                                          |
-|------------------------|------------------|----------|----------------------------------------------------------------------|
-| `remoteTypes`          | List\<String\>   | No       | Remote transport types (OR within). Empty list = no constraint.      |
-| `packageRegistryTypes` | List\<String\>   | No       | Package registry types (OR within). Empty list = no constraint.      |
-| `repositoryExists`     | Boolean          | No       | `true` = must have repo; `false` = must not have repo; null = any.   |
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `remoteTransportTypes` | `List<String>` | No | **Renamed from `remoteTypes`.** Remote transport types (OR). Empty = no constraint. |
+| `packageRegistryTypes` | `List<String>` | No | Package registry types (OR). Empty = no constraint. |
+| `packageTransportTypes` | `List<String>` | No | **New.** Package transport types (OR). Empty = no constraint. |
+| `repositoryExists` | `Boolean` | No | `true` = must have repo; `false` = must not have repo; null = any. |
 
 **Response**: `ServerListResponseDto` (unchanged shape)
 
+---
+
 ## Behavior Contract
 
-### Filter application rules
+### Filter activation rules
 
-1. **No filter specified** (`filter` is null/absent): Single upstream request, no scanning. Identical to current behavior.
-2. **Filter specified with all-empty criteria** (e.g., `{"filter": {"remoteTypes": [], "repositoryExists": null}}`): Treated as no filter — pass-through behavior.
-3. **Filter specified with at least one non-empty criterion**: Multi-page scanning activated. Up to N upstream pages fetched and filtered in memory.
+1. **No filter** (`filter` null/absent or all fields null/empty): Single upstream request, no scanning — identical to existing behavior.
+2. **At least one non-empty field**: Multi-page scanning activated. Up to `maxPagesToScan` upstream pages fetched and filtered in memory.
+
+### Independent dimension evaluation
+
+`packageRegistryTypes` and `packageTransportTypes` are evaluated **independently across all packages** on a server. A server with Package A (OCI, stdio) and Package B (npm, streamable-http) matches `packageRegistryTypes=oci` + `packageTransportTypes=streamable-http` because it has at least one OCI package AND at least one package with streamable-http transport (even though they are different packages).
 
 ### Result count and `limit`
 
-When backend filtering is active, the `limit` parameter controls when to **stop fetching new upstream pages**, not a hard cap on the number of returned servers. The system always processes an entire upstream page once fetched — it does not discard matching servers mid-page. This means a filtered response MAY contain more servers than `limit` (up to one upstream page worth of extra matches). This is intentional: the upstream cursor is an opaque token pointing to the next page, so breaking mid-page would either lose servers permanently or cause duplicates on the next paginated request. When no filter is active (pass-through mode), `limit` is forwarded to the upstream registry and behaves as a strict cap.
+When backend filtering is active, `limit` controls when to **stop fetching new upstream pages**, not a hard cap on returned servers. A filtered response MAY contain more servers than `limit` (up to one upstream page extra) because the system never discards matches mid-page.
 
 ### Pagination contract
 
-| Scenario                                          | `nextCursor` in response | Meaning                                    |
-|---------------------------------------------------|--------------------------|-------------------------------------------|
-| Page filled and upstream has more pages            | Present                  | More results may exist, continue paginating |
-| Scan limit reached, upstream has more pages        | Present                  | More results may exist, continue paginating |
-| Upstream exhausted (no more pages)                 | Null/absent              | All data has been examined                  |
-| Zero results, upstream has more pages              | Present                  | No matches yet, caller can continue         |
-| Zero results, upstream exhausted                   | Null/absent              | No matching servers exist                   |
+| Scenario | `nextCursor` | Meaning |
+|----------|-------------|---------|
+| Page filled, upstream has more pages | Present | More results may exist |
+| Scan limit reached, upstream has more pages | Present | Caller can continue scanning |
+| Upstream exhausted | Null/absent | All data examined |
+| Zero results, upstream has more pages | Present | No matches yet, caller can continue |
+| Zero results, upstream exhausted | Null/absent | No matching servers exist |
 
 ### GET ↔ POST parity
 
-The GET and POST endpoints accept the same filter criteria and produce the same results. The only difference is parameter encoding:
-
-| Filter field           | GET (query param)                        | POST (JSON body)                          |
-|------------------------|------------------------------------------|-------------------------------------------|
-| `remoteTypes`          | `?remoteTypes=sse,streamable-http`       | `"filter": {"remoteTypes": ["sse", "streamable-http"]}` |
-| `packageRegistryTypes` | `?packageRegistryTypes=npm,oci`          | `"filter": {"packageRegistryTypes": ["npm", "oci"]}`     |
-| `repositoryExists`     | `?repositoryExists=true`                 | `"filter": {"repositoryExists": true}`                    |
+| Filter field | GET (repeated params) | POST (JSON body `filter`) |
+|---|---|---|
+| `remoteTransportTypes` | `?remoteTransportTypes=sse&remoteTransportTypes=streamable-http` | `"remoteTransportTypes": ["sse", "streamable-http"]` |
+| `packageRegistryTypes` | `?packageRegistryTypes=npm&packageRegistryTypes=oci` | `"packageRegistryTypes": ["npm", "oci"]` |
+| `packageTransportTypes` | `?packageTransportTypes=stdio` | `"packageTransportTypes": ["stdio"]` |
+| `repositoryExists` | `?repositoryExists=true` | `"repositoryExists": true` |

--- a/specs/009-mcp-registry-filtering/data-model.md
+++ b/specs/009-mcp-registry-filtering/data-model.md
@@ -1,74 +1,74 @@
 # Data Model: MCP Registry Backend Filtering
 
-## New Entities
-
-### ServerFilterDto
-
-Filter criteria for narrowing MCP server search results. Nested inside `ServersRequestDto` as the `filter` field.
-
-| Field                  | Type           | Nullable | Description                                                                                     |
-|------------------------|----------------|----------|-------------------------------------------------------------------------------------------------|
-| `remoteTypes`          | List\<String\> | Yes      | Remote transport types to match (OR logic). Values: "streamable-http", "sse". Matches `remotes[].type`. |
-| `packageRegistryTypes` | List\<String\> | Yes      | Package registry types to match (OR logic). Values: "npm", "pypi", "oci", "nuget", "mcpb". Matches `packages[].registryType`. |
-| `repositoryExists`     | Boolean        | Yes      | If `true`, match servers with non-null repository. If `false`, match servers with null repository. If null/absent, no constraint. |
-
-**Filter logic**:
-- Within a dimension's value list: **OR** (server matches if any value matches)
-- Across dimensions: **AND** (server must satisfy all specified dimensions)
-- Null/absent dimension or empty list: no constraint on that dimension
-
-### Scan Context (internal, not exposed in API)
-
-Tracks multi-page scanning state within the service method. Method-local state — not encoded into the cursor returned to callers. The cursor returned to callers is the raw upstream registry cursor.
-
-| Field           | Type    | Description                                         |
-|-----------------|---------|-----------------------------------------------------|
-| `upstreamCursor`| String  | Current cursor position in the upstream registry     |
-| `pagesScanned`  | int     | Number of upstream pages fetched so far              |
-| `collected`     | List    | Accumulated matching `ServerResponseDto` entries     |
-
 ## Modified Entities
 
-### ServersRequestDto (existing — modified)
+### ServerFilterDto (modified)
 
-Add one new field:
+Flat filter DTO nested inside `ServersRequestDto` as the `filter` field.
 
-| Field    | Type            | Nullable | Description                                                            |
-|----------|-----------------|----------|------------------------------------------------------------------------|
-| `filter` | ServerFilterDto | Yes      | Backend filter criteria. When null/absent, pass-through behavior applies. |
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `remoteTransportTypes` | `List<String>` | Yes | **Renamed from `remoteTypes`.** Remote transport types to match (OR logic). Values: `streamable-http`, `sse`. Matched case-insensitively against `RemoteTransport.type`. |
+| `packageRegistryTypes` | `List<String>` | Yes | Package registry types to match (OR logic). Values: `npm`, `pypi`, `oci`, `nuget`, `mcpb`. Matched case-insensitively against `Package.registryType` enum value. |
+| `packageTransportTypes` | `List<String>` | Yes | **New field.** Package transport types to match (OR logic). Values: `stdio`, `streamable-http`, `sse`. Matched case-insensitively against `Package.transport.type` enum value. A package with null `transport` does not match. |
+| `repositoryExists` | `Boolean` | Yes | `true` = servers with non-null repository; `false` = servers with null repository. Null = no constraint. |
 
-All existing fields (`cursor`, `limit`, `search`, `updatedSince`, `version`) remain unchanged.
+**Cross-dimension logic**: AND. A server must satisfy every non-empty/non-null dimension.
 
-### McpRegistryProperties (existing — modified)
+**Active criteria**: `hasActiveCriteria()` returns `true` when any field is non-null and non-empty (including `packageTransportTypes`).
 
-Add one new field:
+**Filter logic matrix:**
 
-| Field             | Type | Default | Env Variable                      | Description                                          |
-|-------------------|------|---------|-----------------------------------|------------------------------------------------------|
-| `maxPagesToScan`  | int  | 25      | `MCP_REGISTRY_MAX_PAGES_TO_SCAN`  | Maximum upstream pages to scan per filtered request.  |
+| remoteTransportTypes | packageRegistryTypes | packageTransportTypes | repositoryExists | Behavior |
+|---|---|---|---|---|
+| null/empty | null/empty | null/empty | null | Pass-through (no multi-page scan) |
+| ["sse"] | — | — | — | Servers with ≥1 SSE remote |
+| — | ["oci"] | — | — | Servers with ≥1 OCI package |
+| — | — | ["stdio"] | — | Servers with ≥1 package with stdio transport |
+| — | ["oci"] | ["streamable-http"] | — | Servers with ≥1 OCI package AND ≥1 package with streamable-http transport (evaluated independently — may be different packages) |
+
+### ServersRequestDto (unchanged)
+
+`filter` field already present; no changes to this class.
+
+### McpRegistryProperties (unchanged)
+
+`maxPagesToScan` property already present; no changes.
 
 ## Existing Entities (read-only, used in filter evaluation)
 
-The filter predicate method signature is `matches(ServerResponseDto, ServerFilterDto)`. `ServerResponseDto` wraps `ServerDetail` via its `server` field — filter evaluation traverses `serverResponseDto.getServer()` to access the fields below.
-
 ### ServerDetail (accessed via `ServerResponseDto.getServer()`)
 
-Filter evaluation reads these fields:
-
-| Field        | Type                | Filter usage                               |
-|--------------|---------------------|--------------------------------------------|
-| `remotes`    | List\<RemoteTransport\> | Check `type` field against `remoteTypes` filter |
-| `packages`   | List\<Package\>     | Check `registryType` field against `packageRegistryTypes` filter |
-| `repository` | Repository          | Null check for `repositoryExists` filter   |
+| Field | Type | Filter usage |
+|-------|------|-------------|
+| `remotes` | `List<RemoteTransport>` | Check `type` against `remoteTransportTypes` |
+| `packages` | `List<Package>` | Check `registryType` against `packageRegistryTypes`; check `transport.type` against `packageTransportTypes` |
+| `repository` | `Repository` | Null check for `repositoryExists` |
 
 ### RemoteTransport
 
-| Field  | Type   | Filter usage                               |
-|--------|--------|--------------------------------------------|
-| `type` | String | Compared against `remoteTypes` filter values (case-insensitive) |
+| Field | Type | Filter usage |
+|-------|------|-------------|
+| `type` | `String` | Compared against `remoteTransportTypes` values (case-insensitive) |
 
 ### Package
 
-| Field          | Type                | Filter usage                                         |
-|----------------|---------------------|------------------------------------------------------|
-| `registryType` | PackageRegistryType | Enum `.getValue()` compared against `packageRegistryTypes` filter values |
+| Field | Type | Filter usage |
+|-------|------|-------------|
+| `registryType` | `PackageRegistryType` | `enum.getValue()` compared against `packageRegistryTypes` values (case-insensitive) |
+| `transport` | `LocalTransport` (nullable) | `transport.type.getValue()` compared against `packageTransportTypes` values (case-insensitive); null transport = no match |
+
+### LocalTransport
+
+| Field | Type | Values |
+|-------|------|--------|
+| `type` | `LocalTransportType` | `STDIO("stdio")`, `STREAMABLE_HTTP("streamable-http")`, `SSE("sse")` |
+
+## Scan Context (internal, method-local, not persisted)
+
+| Variable | Type | Purpose |
+|----------|------|---------|
+| `collected` | `List<ServerResponseDto>` | Accumulated matching results across pages |
+| `currentCursor` | `String` | Cursor for next upstream fetch |
+| `lastSuccessfulCursor` | `String` | Cursor returned to caller when scan limit reached |
+| `pagesScanned` | `int` | Count of pages fetched; stops at `maxPagesToScan` |

--- a/specs/009-mcp-registry-filtering/plan.md
+++ b/specs/009-mcp-registry-filtering/plan.md
@@ -1,41 +1,44 @@
 # Implementation Plan: MCP Registry Backend Filtering
 
-**Branch**: `009-mcp-registry-filtering` | **Date**: 2026-03-18 | **Spec**: [spec.md](./spec.md)
+**Branch**: `009-mcp-registry-filtering` | **Date**: 2026-04-02 | **Spec**: [spec.md](./spec.md)
 **Input**: Feature specification from `/specs/009-mcp-registry-filtering/spec.md`
 
 ## Summary
 
-Add backend-side filtering to the MCP registry server list endpoints. The upstream MCP registry only supports name-based search — this feature adds filtering by remote transport type, package registry type, and repository existence. When filters are applied, the service scans up to N upstream pages, filtering results in memory, and returns a single page of matching servers. This is Phase 1 (prototype); Phase 2 will replace the scanning with a local aggregator data store.
+Add `packageTransportTypes` filter field to the existing backend-filtering mechanism, and rename
+`remoteTypes` → `remoteTransportTypes` for consistency. All filter fields remain flat on
+`ServerFilterDto`; each is evaluated independently across all server entities with OR within a
+field and AND across fields. No schema migrations required — this is a pure API/service change.
 
 ## Technical Context
 
-**Language/Version**: Java 21, Spring Boot 3.5.10, Gradle 8.13
-**Primary Dependencies**: OkHttpClient (HTTP), Jackson (JSON), Lombok, MapStruct
-**Storage**: N/A (in-memory filtering; no database changes)
-**Testing**: JUnit 5, Mockito, AssertJ, MockMvc; `./gradlew testFast` for dev cycle
-**Target Platform**: Linux server (Spring Boot web service)
+**Language/Version**: Java 21, Spring Boot 3.5.10
+**Primary Dependencies**: Spring Web MVC, Lombok, SpringDoc OpenAPI 2.8.5, Apache Commons Collections4
+**Storage**: N/A — no DB changes
+**Testing**: JUnit 5 + AssertJ + Spring MockMvc (`@WebMvcTest`); `./gradlew testFast`
+**Target Platform**: Linux server (Spring Boot REST service)
 **Project Type**: Web service (REST API)
-**Performance Goals**: Bounded by scan limit — max N sequential upstream HTTP calls per request
-**Constraints**: Max pages to scan configurable (default 5); no changes to upstream API contract
-**Scale/Scope**: Modifies 3 existing files, adds 2 new classes, adds test fixtures
+**Performance Goals**: No new latency targets; bounded by existing `maxPagesToScan` (default 25)
+**Constraints**: GET multi-value params via repeated param name (Spring MVC `List<String>` binding)
+**Scale/Scope**: Touches 4 source files + 3 test files; no migrations; no new dependencies
 
 ## Constitution Check
 
-*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+*GATE: Must pass before implementation.*
 
-| Gate | Status | Notes |
+| Rule | Status | Notes |
 |------|--------|-------|
-| Layered architecture (web → service → dao/kubernetes) | PASS | Controller calls service; service calls client. No layer violations. |
-| `@LogExecution` on all Spring components | PASS | New `McpServerFilter` component will carry `@LogExecution`. |
-| MapStruct `componentModel = "spring"` | N/A | No new mappers needed. |
-| `@Transactional` only on service/dao layers | N/A | No transactions involved. |
-| Kubernetes isolation | N/A | No K8s changes. |
-| Checkstyle (Google Java Style, 180-char lines) | PASS | Will verify with `./gradlew checkstyleMain checkstyleTest`. |
-| No wildcard imports | PASS | Standard imports only. |
-| Test naming: `shouldDoX()` / `shouldFailDoX_whenY()` | PASS | All new tests follow convention. |
-| `docs/configuration.md` updated for new config | PASS | New env var `MCP_REGISTRY_MAX_PAGES_TO_SCAN` will be documented. |
-| `CollectionUtils.isEmpty()`/`isNotEmpty()` for null-safe checks | PASS | Will use for null/empty list checks in filter. |
-| `StringUtils` for string checks | PASS | Will use where applicable. |
+| Strict Layered Architecture (web → service → dao) | ✅ Pass | Controller builds filter, service orchestrates, McpServerFilter is `@Component` |
+| `@LogExecution` on every Spring component | ✅ Pass | Already present on `McpRegistryController`, `McpRegistryService`, `McpServerFilter` |
+| `@Transactional` only on service/dao | ✅ Pass | No transactions involved |
+| OpenAPI `@Operation` + `@ApiResponse` on every endpoint | ✅ Pass | Must update `@Parameter` docs for renamed/new params |
+| No wildcard imports | ✅ Pass | Enforced by Checkstyle |
+| Configuration property defaults in `application.yml` only | ✅ Pass | `max-pages-to-scan` default already in YAML; no new properties |
+| `docs/configuration.md` update | ✅ Required | No new env vars added — `MCP_REGISTRY_MAX_PAGES_TO_SCAN` already documented; verify |
+| Google Java Style / 180-char line limit | ✅ Pass | Verify with `./gradlew checkstyleMain checkstyleTest` |
+| CollectionUtils for null+empty checks | ✅ Pass | Already used in `McpServerFilter` |
+
+**No violations.** Complexity tracking table not required.
 
 ## Project Structure
 
@@ -43,58 +46,94 @@ Add backend-side filtering to the MCP registry server list endpoints. The upstre
 
 ```text
 specs/009-mcp-registry-filtering/
-├── plan.md              # This file
-├── spec.md              # Feature specification
-├── research.md          # Phase 0 output — technical decisions
-├── data-model.md        # Phase 1 output — entity definitions
-├── quickstart.md        # Phase 1 output — implementation guide
+├── plan.md              ← this file
+├── research.md          ← updated with Decision 2 revision
+├── data-model.md        ← filter DTO fields + logic matrix
 ├── contracts/
-│   └── api.md           # Phase 1 output — API contract
-└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+│   └── server-filter-api.md   ← GET params + POST body shape
+└── tasks.md             ← generated by /speckit.tasks
 ```
 
-### Source Code (repository root)
+### Source Code (affected files only)
 
 ```text
-src/main/java/com/epam/aidial/deployment/manager/registry/mcp/
-├── client/
-│   └── McpRegistryClient.java              # UNCHANGED — single-page HTTP client
-├── model/
-│   └── (existing models)                    # UNCHANGED
-├── properties/
-│   └── McpRegistryProperties.java           # MODIFIED — add maxPagesToScan
-├── service/
-│   ├── McpRegistryService.java              # MODIFIED — multi-page scanning loop
-│   └── McpServerFilter.java                 # NEW — filter predicate component
-└── web/
-    ├── controller/
-    │   └── McpRegistryController.java       # MODIFIED — add filter query params
-    └── dto/
-        ├── ServersRequestDto.java           # MODIFIED — add filter field
-        └── ServerFilterDto.java             # NEW — filter criteria DTO
+src/main/java/.../registry/mcp/
+├── web/
+│   ├── controller/
+│   │   └── McpRegistryController.java        ← rename remoteTypes param, add packageTransportTypes param
+│   └── dto/
+│       └── ServerFilterDto.java              ← rename remoteTypes, add packageTransportTypes
+└── service/
+    └── McpServerFilter.java                  ← add packageTransportTypes matching logic
 
-src/main/resources/
-└── application.yml                          # MODIFIED — add max-pages-to-scan
-
-src/test/java/com/epam/aidial/deployment/manager/mcpregistry/
-├── service/
-│   ├── McpServerFilterTest.java             # NEW — unit tests for filter predicate
-│   └── McpRegistryServiceTest.java          # NEW — unit tests for scanning loop
-└── web/controller/
-    └── McpRegistryControllerTest.java       # MODIFIED — add filter param tests
-
-src/test/resources/mcp-registry/
-├── servers_page.json                        # EXISTING
-├── server_version.json                      # EXISTING
-├── servers_page_mixed.json                  # NEW — servers with diverse properties
-└── servers_page_empty.json                  # NEW — empty results page
-
-docs/
-└── configuration.md                         # MODIFIED — document new env var
+src/test/java/.../mcpregistry/
+├── web/controller/
+│   └── McpRegistryControllerTest.java        ← update/add GET filter param tests
+└── service/
+    └── McpServerFilterTest.java              ← add packageTransportTypes test cases
 ```
 
-**Structure Decision**: All changes fit within the existing `registry/mcp/` package hierarchy. Two new classes (`ServerFilterDto`, `McpServerFilter`) follow existing naming conventions. No new packages needed.
+**Structure Decision**: Single-project layout; changes are confined to the existing
+`registry/mcp/` package tree. No new packages or modules required.
 
 ## Complexity Tracking
 
-No constitution violations. No complexity justifications needed.
+> No constitution violations — table not applicable.
+
+## Phase 0: Research
+
+**Status**: Complete — see [research.md](./research.md)
+
+Key decisions relevant to this change:
+
+| # | Decision | Outcome |
+|---|----------|---------|
+| 1 | Filter field types | `String` for all filter lists; case-insensitive comparison |
+| 2 | DTO structure | Flat fields; `packageTransportTypes` added as independent dimension |
+| 3 | Scanning location | `McpRegistryService` loop; `McpServerFilter` predicate |
+| 4 | Filter predicate | Dedicated `McpServerFilter` `@Component` |
+| 5 | Scan limit default | 25 pages (already in place) |
+| 6 | Full-page collection | No mid-page break (already in place) |
+
+No NEEDS CLARIFICATION items remain.
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+See [data-model.md](./data-model.md) for the full field inventory and logic matrix.
+
+**`ServerFilterDto` — after this change:**
+
+| Field | Type | Cardinality | Logic | Matches against |
+|-------|------|-------------|-------|-----------------|
+| `remoteTransportTypes` | `List<String>` | 0..N | OR within; AND with others | `RemoteTransport.type` |
+| `packageRegistryTypes` | `List<String>` | 0..N | OR within; AND with others | `Package.registryType` (enum value) |
+| `packageTransportTypes` | `List<String>` | 0..N | OR within; AND with others | `Package.transport.type` (enum value) |
+| `repositoryExists` | `Boolean` | 0..1 | AND with others | `ServerDetail.repository != null` |
+
+`PackageTransportType` valid values: `stdio`, `streamable-http`, `sse` (case-insensitive; matches `LocalTransportType` enum values).
+
+**`hasActiveCriteria` update**: must also return `true` when `packageTransportTypes` is non-empty.
+
+### API Contracts
+
+See [contracts/server-filter-api.md](./contracts/server-filter-api.md) for full request/response shape.
+
+**Summary of changes:**
+
+| Endpoint | Change |
+|----------|--------|
+| `GET /api/v1/mcp-registry/servers` | Rename `remoteTypes` → `remoteTransportTypes`; add `packageTransportTypes` repeated param |
+| `POST /api/v1/mcp-registry/servers/list` | Rename `remoteTypes` → `remoteTransportTypes` in body; add `packageTransportTypes` |
+
+Response shape unchanged.
+
+### Implementation Steps
+
+1. **`ServerFilterDto`** — rename `remoteTypes` → `remoteTransportTypes`; add `packageTransportTypes`
+2. **`McpServerFilter`** — add `matchesPackageTransportTypes()` private method; update `hasActiveCriteria()` to include the new field; update `matches()` to apply the new dimension
+3. **`McpRegistryController`** — rename `remoteTypes` param to `remoteTransportTypes`; add `packageTransportTypes` param; update `buildFilter()` helper; update `@Parameter` OpenAPI docs
+4. **`McpServerFilterTest`** — rename references to `remoteTypes`; add test cases for `packageTransportTypes` (single value, multi-value OR, case-insensitive, null transport, empty packages, AND with other dimensions); update `hasActiveCriteria` tests
+5. **`McpRegistryControllerTest`** — update GET test assertions for renamed param; add test for `packageTransportTypes` query param binding
+6. **Checkstyle + tests** — run `./gradlew checkstyleMain checkstyleTest testFast`

--- a/specs/009-mcp-registry-filtering/research.md
+++ b/specs/009-mcp-registry-filtering/research.md
@@ -15,17 +15,17 @@
 
 ## Decision 2: Filter DTO Structure (Flat vs Nested)
 
-**Decision**: Add a nested `ServerFilterDto` object as a `filter` field inside `ServersRequestDto`. The filter DTO uses concept-based field naming (`remoteTypes`, `packageRegistryTypes`, `repositoryExists`).
+**Decision**: `ServerFilterDto` uses flat fields: `remoteTransportTypes` (renamed from `remoteTypes`), `packageRegistryTypes` (existing), `packageTransportTypes` (new), `repositoryExists` (existing). No nested sub-objects. The `filter` field on `ServersRequestDto` remains a single `ServerFilterDto`.
 
 **Rationale**:
-- Spec FR-002 requires filters organized around server domain concepts.
-- A nested `filter` object separates filter concerns from pagination/search params (`cursor`, `limit`, `search`, `updatedSince`, `version`).
-- Naming convention (`remoteTypes`, `packageRegistryTypes`, `repositoryExists`) makes the domain concept clear without deep nesting.
-- For the GET endpoint, the controller accepts flat query params and constructs the filter DTO manually (matching existing controller patterns).
+- Clarification session (2026-04-02) confirmed flat fields over list-of-criteria structure.
+- Co-location requirement (same package must match both registry type and transport type) was explicitly dropped — each field is evaluated independently across all packages.
+- Flat structure keeps the DTO, the GET query param binding, and the filter predicate straightforward with no additional object graph.
+- For GET: multi-value fields use repeated param names (`remoteTransportTypes=sse&remoteTransportTypes=streamable-http`) — standard Spring MVC `List<String>` binding.
 
 **Alternatives considered**:
-- Flat fields directly on `ServersRequestDto` — rejected because it mixes filtering concerns with pagination and makes future extension harder.
-- Deep nesting (`filter.remotes.types`, `filter.packages.registryTypes`) — rejected as over-engineering for 3 filter fields.
+- List-of-criteria per package (`packages: [{registryTypes, transportTypes}]`) with co-located AND — rejected because the co-location requirement was dropped in clarification.
+- Deep nesting (`filter.remotes.transportTypes`, `filter.packages.registryTypes`) — rejected as over-engineering for flat independent fields.
 
 ## Decision 3: Multi-Page Scanning Location
 

--- a/specs/009-mcp-registry-filtering/spec.md
+++ b/specs/009-mcp-registry-filtering/spec.md
@@ -15,13 +15,23 @@ This feature follows a two-phase delivery strategy:
 
 **Design constraint**: The filter API contract (request parameters and response shape) introduced in Phase 1 MUST be designed as the permanent interface that survives the transition to Phase 2. Callers should not need to change when the underlying implementation switches from multi-page scanning to aggregator-based storage. No special "preview" or "prototype" labeling in the API — the contract is stable from day one.
 
+## Clarifications
+
+### Session 2026-04-02
+
+- Q: Should the filter DTO use flat fields or a list-of-criteria structure for package filtering? → A: Flat fields — `remoteTransportTypes` (renamed from `remoteTypes`), `packageRegistryTypes` (existing), `packageTransportTypes` (new), `repositoryExists` (existing). Package registry type and package transport type filters are evaluated independently across all packages on the server (no co-location requirement).
+- Q: Do the filter endpoints require additional authorization beyond the existing list-servers endpoint auth? → A: Same auth as existing list-servers — no additional restriction.
+- Q: When the upstream errors mid-scan after some results are collected, what should the system return? → A: Return collected results if any; propagate the error only if zero results were collected (existing edge case behavior retained).
+- Q: How should multi-value filter fields be encoded as GET query parameters? → A: Repeated param name — `remoteTransportTypes=sse&remoteTransportTypes=streamable-http` (standard Spring MVC List binding).
+- Q: Should there be a configurable per-request timeout for multi-page scans? → A: No explicit timeout — rely on existing HTTP client/server timeouts configured at infrastructure level.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Filter MCP Servers by Properties Not Supported by Registry (Priority: P1)
 
-An administrator browsing MCP servers wants to narrow results by properties the upstream MCP registry does not support filtering on — such as remote transport type, package registry type, or repository presence. The system reads multiple pages from the upstream registry behind the scenes, applies the requested filters in memory, and returns a single page of matching results to the caller.
+An administrator browsing MCP servers wants to narrow results by properties the upstream MCP registry does not support filtering on — such as remote transport type, package registry type, package transport type, or repository presence. The system reads multiple pages from the upstream registry behind the scenes, applies the requested filters in memory, and returns a single page of matching results to the caller.
 
-The filter model is designed to be expressive and extensible. Rather than flat top-level filter parameters, filters are structured around the server's domain concepts (remotes, packages, repository) so that new filter criteria can be added to each concept without changing the overall request shape. Each filter criterion accepts a list of values with OR logic within it (e.g., remote type = ["sse", "streamable-http"] matches servers with either transport), while AND logic applies across different filter dimensions.
+The filter model uses flat fields organized around the server's domain concepts (remotes, packages, repository). Each field accepts a list of values with OR logic within it. AND logic applies across different filter dimensions. The package registry type and package transport type filters are independent — each is evaluated across all packages on the server separately (a server matches `packageRegistryTypes=["oci"]` + `packageTransportTypes=["streamable-http"]` if it has at least one OCI package AND at least one package with streamable-http transport, which may or may not be the same package).
 
 **Why this priority**: This is the core value of the feature. Without backend-side filtering, users must manually browse through large numbers of servers to find ones matching their criteria, which is impractical for registries with thousands of entries.
 
@@ -36,8 +46,10 @@ The filter model is designed to be expressive and extensible. Rather than flat t
 5. **Given** a user requests servers filtered by "repository does not exist", **Then** only servers without a repository are returned.
 6. **Given** a user requests servers filtered by remote type ["sse", "streamable-http"], **Then** servers that have at least one remote of type "sse" OR at least one remote of type "streamable-http" are returned.
 7. **Given** a user requests servers filtered by package registry type ["npm", "pypi"], **Then** servers that have at least one npm package OR at least one pypi package are returned.
-8. **Given** a backend filter is applied and the first upstream page has no matching servers, **When** the system fetches subsequent pages, **Then** the system continues fetching up to N pages until it collects enough results to fill the requested page size or exhausts the maximum page scan limit.
-9. **Given** a backend filter is applied alongside the existing `search` parameter, **When** the request is made, **Then** the `search` parameter is forwarded to the upstream registry (server-side) while the backend filter is applied in memory to the results.
+8. **Given** the upstream registry contains servers with various package transport types, **When** a user requests servers filtered by package transport type ["stdio"], **Then** only servers that have at least one package with `transport.type = "stdio"` are returned.
+9. **Given** a user requests servers filtered by `packageRegistryTypes: ["oci"]` AND `packageTransportTypes: ["streamable-http"]`, **When** the results are returned, **Then** servers that have at least one OCI package AND at least one package with streamable-http transport are returned — these may be different packages on the same server.
+10. **Given** a backend filter is applied and the first upstream page has no matching servers, **When** the system fetches subsequent pages, **Then** the system continues fetching up to N pages until it collects enough results to fill the requested page size or exhausts the maximum page scan limit.
+11. **Given** a backend filter is applied alongside the existing `search` parameter, **When** the request is made, **Then** the `search` parameter is forwarded to the upstream registry (server-side) while the backend filter is applied in memory to the results.
 
 ---
 
@@ -47,14 +59,15 @@ An administrator wants to find servers that match several criteria at once — f
 
 **Why this priority**: Same priority as basic filtering — combining filters is not an add-on, it is inherent to how the filter model works. Each filter dimension independently contributes to a single AND predicate.
 
-**Independent Test**: Can be tested by sending a request with multiple filter criteria (e.g., remote type + package type + repository exists) and verifying the returned servers satisfy all conditions.
+**Independent Test**: Can be tested by sending a request with multiple filter dimensions (e.g., remoteTransportTypes + packageRegistryTypes + repositoryExists) and verifying the returned servers satisfy all conditions.
 
 **Acceptance Scenarios**:
 
-1. **Given** a user requests servers with remote type ["sse"] AND package registry type ["npm"], **When** the results are returned, **Then** every server in the results has at least one SSE remote AND at least one npm package.
-2. **Given** a user requests servers with package registry type ["oci"] AND repository exists, **When** the results are returned, **Then** every server has at least one OCI package AND a non-null repository.
-3. **Given** a user requests servers with remote type ["sse", "streamable-http"] AND package registry type ["npm", "pypi"], **When** the results are returned, **Then** every server has (at least one SSE or streamable-http remote) AND (at least one npm or pypi package).
+1. **Given** a user requests servers with `remoteTransportTypes: ["sse"]` AND `packageRegistryTypes: ["npm"]`, **When** the results are returned, **Then** every server in the results has at least one SSE remote AND at least one npm package.
+2. **Given** a user requests servers with `packageRegistryTypes: ["oci"]` AND `repositoryExists: true`, **When** the results are returned, **Then** every server has at least one OCI package AND a non-null repository.
+3. **Given** a user requests servers with `remoteTransportTypes: ["sse", "streamable-http"]` AND `packageRegistryTypes: ["npm", "pypi"]`, **When** the results are returned, **Then** every server has (at least one SSE or streamable-http remote) AND (at least one npm or pypi package).
 4. **Given** a user specifies only one filter dimension, **When** the results are returned, **Then** only that single dimension is applied — no implicit defaults on other filter dimensions.
+5. **Given** a user requests servers with `packageRegistryTypes: ["oci"]` AND `packageTransportTypes: ["streamable-http"]`, **When** the results are returned, **Then** every server has at least one OCI package AND at least one package with streamable-http transport (evaluated independently across all packages).
 
 ---
 
@@ -99,9 +112,10 @@ An operator deploying the system wants to control how many upstream registry pag
 - What happens when no backend filters are specified? The request is passed through to the upstream registry without any multi-page scanning — existing behavior is preserved.
 - What happens when the upstream registry has fewer pages than the scan limit? The system stops when the upstream indicates no more pages (null nextCursor) and returns collected results with null cursor.
 - What happens when a user provides a backend filter on the GET endpoint (query params)? The filters are accepted as query parameters the same way they are in the POST request body.
-- What happens when a server has null/empty `packages` list and a package type filter is applied? The server does not match the filter and is excluded.
+- What happens when a server has null/empty `packages` list and a package criterion filter is applied? The server does not match the filter and is excluded.
 - What happens when a server has null/empty `remotes` list and a remote type filter is applied? The server does not match the filter and is excluded.
 - What happens when a filter criterion has an empty list of values (e.g., remote type = [])? An empty list is treated as "no filter on this dimension" — equivalent to omitting the criterion entirely.
+- What happens when `packageTransportTypes` is specified but a package has a null `transport` field? That package does not match the transport type filter and is skipped; the server matches only if another of its packages has a non-null transport with a matching type.
 - What happens when a single upstream page has more matching servers than the requested limit? The system collects all matches from that page and returns them, even if the count exceeds `limit`. This is intentional: the upstream cursor is an opaque token pointing to the next page, so breaking mid-page would permanently lose unprocessed matches. The `limit` controls when to stop fetching new pages, not a hard cap on results.
 
 ## Requirements *(mandatory)*
@@ -111,12 +125,14 @@ An operator deploying the system wants to control how many upstream registry pag
 **Filter model**
 
 - **FR-001**: System MUST accept a structured filter object on the list-servers endpoints (both GET and POST variants) for properties not supported by the upstream MCP registry.
-- **FR-002**: The filter model MUST be organized around server domain concepts — `remotes`, `packages`, and `repository` — so that each concept can carry its own set of filter criteria independently.
-- **FR-003**: System MUST support filtering by remote transport type — matching servers that have at least one remote entry whose type matches any of the specified values (case-insensitive comparison, e.g., ["streamable-http", "sse"]). Values within the list are combined with OR logic.
-- **FR-004**: System MUST support filtering by package registry type — matching servers that have at least one package whose registry type matches any of the specified values (case-insensitive comparison, e.g., ["npm", "oci"]). Values within the list are combined with OR logic.
-- **FR-005**: System MUST support filtering by repository existence — matching servers that have a non-null repository (exists = true) or a null repository (exists = false).
-- **FR-006**: When multiple filter dimensions are specified, they MUST be combined with AND logic — a server must satisfy every specified dimension to be included in results. Within a single dimension's value list, OR logic applies.
-- **FR-007**: When a filter dimension is omitted (null/absent) or its value list is empty, it MUST NOT constrain results — only explicitly provided criteria with non-empty values participate in filtering.
+- **FR-002**: The filter model uses flat fields grouped by server domain concept (`remotes`, `packages`, `repository`). Each field is evaluated independently across all matching entities on the server.
+- **FR-003**: System MUST support filtering by remote transport type via `remoteTransportTypes` — matching servers that have at least one remote entry whose `type` matches any of the specified values (case-insensitive, e.g., ["streamable-http", "sse"]). Values are combined with OR logic.
+- **FR-004**: System MUST support filtering by package registry type via `packageRegistryTypes` — matching servers that have at least one package whose `registryType` matches any of the specified values (case-insensitive, e.g., ["npm", "pypi", "oci", "nuget", "mcpb"]). Values are combined with OR logic.
+- **FR-004b**: System MUST support filtering by package transport type via `packageTransportTypes` — matching servers that have at least one package whose `transport.type` matches any of the specified values (case-insensitive, e.g., ["stdio", "streamable-http", "sse"]). Values are combined with OR logic. This filter is evaluated independently from `packageRegistryTypes` — the matching package does not need to be the same package.
+- **FR-005**: System MUST support filtering by repository existence via `repositoryExists` — matching servers that have a non-null repository (`true`) or a null repository (`false`).
+- **FR-006**: When multiple filter fields are specified, they MUST be combined with AND logic — a server must satisfy every specified field to be included in results. Within a single field's value list, OR logic applies.
+- **FR-007**: When a filter field is omitted (null/absent) or its value list is empty, it MUST NOT constrain results — only explicitly provided fields with non-empty values participate in filtering.
+- **FR-007a**: On the GET endpoint, multi-value filter fields MUST be accepted as repeated query parameters (e.g., `remoteTransportTypes=sse&remoteTransportTypes=streamable-http`), consistent with standard Spring MVC `List<String>` binding.
 
 **Multi-page scanning (Phase 1 — Prototype)**
 
@@ -139,7 +155,13 @@ An operator deploying the system wants to control how many upstream registry pag
 
 ### Key Entities
 
-- **Server Filter**: A structured set of filter criteria organized by domain concept. Contains optional sub-filters for remotes (list of transport types, OR logic), packages (list of registry types, OR logic), and repository (existence boolean). Across dimensions, AND logic applies. When the entire filter is empty/absent, no backend filtering occurs.
+- **Server Filter**: A flat set of optional filter fields evaluated with AND logic across dimensions and OR logic within each field's value list:
+  - `remoteTransportTypes`: list of strings matched against `RemoteTransport.type` ("streamable-http", "sse").
+  - `packageRegistryTypes`: list of strings matched against `Package.registryType` ("npm", "pypi", "oci", "nuget", "mcpb").
+  - `packageTransportTypes`: list of strings matched against `Package.transport.type` ("stdio", "streamable-http", "sse"). Evaluated independently from `packageRegistryTypes`.
+  - `repositoryExists`: boolean — true requires non-null repository, false requires null repository.
+
+  When the entire filter is null/absent or all fields are empty/null, no backend filtering occurs.
 - **Scan Context**: Tracks the current upstream cursor position, the number of pages scanned so far, and accumulated matching results. This is method-local state within the service — it is not encoded into the cursor returned to the caller. The cursor returned to callers is the raw upstream registry cursor. This entity is specific to Phase 1 and will be replaced by standard database pagination in Phase 2.
 
 ### Assumptions
@@ -147,12 +169,13 @@ An operator deploying the system wants to control how many upstream registry pag
 - The upstream MCP Registry API remains stable at `v0.1` for the duration of Phase 1.
 - The registry's cursor-based pagination is deterministic — the same cursor always resumes from the same position.
 - Phase 2 (aggregator-based storage) will be specified as a separate feature; this spec covers only Phase 1.
+- The filter endpoints inherit the same authorization as the existing list-servers endpoints — no additional role restriction is applied to filtering.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: Users can filter MCP servers by remote transport type, package registry type, and repository existence in a single request and receive only matching results.
+- **SC-001**: Users can filter MCP servers by remote transport type (`remoteTransportTypes`), package registry type (`packageRegistryTypes`), package transport type (`packageTransportTypes`), and repository existence (`repositoryExists`) in a single request and receive only matching results.
 - **SC-002**: Filters are composable — any combination of the supported filter dimensions can be used together, with multiple values per dimension (OR within, AND across).
 - **SC-003**: Paginated browsing through filtered results works seamlessly — callers paginate using `nextCursor` identically whether filters are applied or not, with no duplicates or missing servers between pages.
 - **SC-004**: When no backend filters are provided, the system behaves identically to the current implementation with no additional upstream requests.

--- a/specs/009-mcp-registry-filtering/tasks.md
+++ b/specs/009-mcp-registry-filtering/tasks.md
@@ -1,100 +1,78 @@
 # Tasks: MCP Registry Backend Filtering
 
 **Input**: Design documents from `/specs/009-mcp-registry-filtering/`
-**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/api.md
+**Prerequisites**: plan.md ✅, spec.md ✅, data-model.md ✅, contracts/api.md ✅, research.md ✅
 
-**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
 
 ## Format: `[ID] [P?] [Story] Description`
 
-- **[P]**: Can run in parallel (different files, no dependencies)
-- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to
 - Include exact file paths in descriptions
+
+## Path Conventions
+
+Single-project layout: `src/main/java/…`, `src/test/java/…` at repository root.
+Base package: `com.epam.aidial.deployment.manager.registry.mcp`
 
 ---
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-**Purpose**: Create shared DTOs, configuration, and test fixtures that all user stories depend on
-
-- [X] T001 Create `ServerFilterDto` DTO with `remoteTypes` (List\<String\>), `packageRegistryTypes` (List\<String\>), and `repositoryExists` (Boolean) fields in `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/dto/ServerFilterDto.java`
-- [X] T002 [P] Add `filter` field (type `ServerFilterDto`, nullable) to `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/dto/ServersRequestDto.java`
-- [X] T003 [P] Add `maxPagesToScan` field (int, default 5) to `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/properties/McpRegistryProperties.java` and add `max-pages-to-scan: ${MCP_REGISTRY_MAX_PAGES_TO_SCAN:5}` to `src/main/resources/application.yml` under `app.mcp-registry`
-- [X] T004 [P] Create test JSON fixtures: `src/test/resources/mcp-registry/servers_page_mixed.json` (servers with diverse remotes, packages, repositories), `src/test/resources/mcp-registry/servers_page_empty.json` (empty server list with no nextCursor)
+No setup required — this is a modification to an existing Spring Boot project with all infrastructure in place.
 
 ---
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-**Purpose**: Filter predicate component — MUST be complete before any user story implementation
+**Purpose**: Rename `remoteTypes` → `remoteTransportTypes` and add `packageTransportTypes` in `ServerFilterDto`. This is the single DTO change that all downstream source and test files depend on.
 
-**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+**⚠️ CRITICAL**: Tasks T002 and T003 cannot start until T001 is complete.
 
-- [X] T005 Create `McpServerFilter` Spring component with `matches(ServerResponseDto, ServerFilterDto)` method implementing: remote type matching (OR within list, case-insensitive against `server.getServer().getRemotes()[].type`), package registry type matching (OR within list, case-insensitive against `server.getServer().getPackages()[].registryType.getValue()`), repository existence check (null check on `server.getServer().getRepository()`). Use `CollectionUtils.isEmpty()` for null-safe collection checks. Add `@LogExecution` and `@Component` annotations. File: `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/service/McpServerFilter.java`
-- [X] T006 Create unit tests for `McpServerFilter` covering: single remote type match, multi-value remote type OR logic, single package type match, multi-value package type OR logic, repository exists=true, repository exists=false, null/empty remotes with remote filter (should not match), null/empty packages with package filter (should not match), null filter (should match all), empty filter lists (should match all). File: `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpServerFilterTest.java`
+- [x] T001 Rename field `remoteTypes` → `remoteTransportTypes` (update field name, Lombok builder key, and Javadoc) and add new field `@Nullable private List<String> packageTransportTypes` with Javadoc: "Package transport types to match (OR logic). Values: stdio, streamable-http, sse. Matched case-insensitively against Package.transport.type. A package with null transport does not match." in `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/dto/ServerFilterDto.java`
 
-**Checkpoint**: Filter predicate is ready and tested — user story implementation can now begin
-
----
-
-## Phase 3: User Story 1+2 — Filter & Combine MCP Servers (Priority: P1) 🎯 MVP
-
-**Goal**: Administrators can filter MCP servers by remote type, package type, and repository existence. Multiple filters combine with AND logic across dimensions, OR logic within a dimension's value list.
-
-**Independent Test**: Send a list-servers request with filter params (e.g., `remoteTypes=sse&packageRegistryTypes=npm&repositoryExists=true`) and verify only matching servers are returned.
-
-### Implementation
-
-- [X] T007 [US1] [US2] Implement multi-page scanning loop in `McpRegistryService.getServers()`: when `ServerFilterDto` has active criteria, iterate upstream pages using `McpRegistryClient.getServers()`, apply `McpServerFilter.matches()` to each server, accumulate results until page size is filled or scan limit (`McpRegistryProperties.maxPagesToScan`) is reached or upstream exhausted. When no filter is active, preserve existing single-request pass-through behavior. Handle upstream errors mid-scan: if `McpRegistryClientException` is thrown and results have already been collected, return the partial results with the last successful cursor; if no results collected yet, propagate the exception. Upstream-supported filters (`search`, `updatedSince`, `version`) MUST remain on the request forwarded to the upstream registry alongside backend filtering. File: `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/service/McpRegistryService.java`
-- [X] T008 [US1] [US2] Update GET endpoint in `McpRegistryController.getServers()` to accept new query params: `remoteTypes` (List\<String\>), `packageRegistryTypes` (List\<String\>), `repositoryExists` (Boolean). Construct `ServerFilterDto` from these params and set it on the `ServersRequestDto`. File: `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/controller/McpRegistryController.java`
-- [X] T009 [US1] [US2] Create unit tests for `McpRegistryService` scanning loop covering: single filter dimension returns only matching servers, multiple filter dimensions use AND logic, multi-value filter uses OR within dimension, no filter preserves pass-through (single upstream call), upstream returns mixed servers and only matching ones are collected, first page has no matches but subsequent pages do — loop continues, error mid-scan with partial results returns collected results, error mid-scan with no results propagates exception, upstream `search` param is still forwarded when backend filter is also active. Mock `McpRegistryClient` and `McpServerFilter`. File: `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpRegistryServiceTest.java`
-- [X] T010 [US1] [US2] Add controller tests: GET with `remoteTypes` param passes filter to service, GET with `packageRegistryTypes` param passes filter to service, GET with `repositoryExists` param passes filter to service, GET with multiple filter params combines them, GET with no filter params results in null filter (pass-through), POST with `filter` object in JSON body passes filter to service. File: `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/web/controller/McpRegistryControllerTest.java`
-
-**Checkpoint**: Filtering and combining works for both GET and POST endpoints. MVP is functional.
+**Checkpoint**: `ServerFilterDto` compiles — all downstream tasks can begin.
 
 ---
 
-## Phase 4: User Story 3 — Paginate Through Filtered Results (Priority: P2)
+## Phase 3: User Story 1 — Filter MCP Servers by Properties (Priority: P1) 🎯 MVP
 
-**Goal**: Callers can paginate through filtered results using `nextCursor`, identically to non-filtered pagination. Scan limit hit returns a cursor; upstream exhausted returns null cursor.
+**Goal**: `McpServerFilter` evaluates the new `packageTransportTypes` dimension; `McpRegistryController` exposes the renamed `remoteTransportTypes` and new `packageTransportTypes` GET query params. Both endpoints (GET and POST) accept the updated filter shape.
 
-**Independent Test**: Request first page of filtered servers, use returned cursor for next page, verify no duplicates and proper continuation.
+**Independent Test**: `GET /api/v1/mcp-registry/servers?packageTransportTypes=stdio` returns only servers that have at least one package with `transport.type = "stdio"`. `GET /api/v1/mcp-registry/servers?remoteTransportTypes=sse` still works after the rename (old `remoteTypes` param no longer accepted).
 
-**Depends on**: Phase 3 (scanning loop must exist)
+### Implementation for User Story 1
 
-### Implementation
+- [x] T002 [P] [US1] Add private method `matchesPackageTransportTypes(List<Package> packages, List<String> filterTypes)` — returns `false` when packages is null/empty; iterates packages and returns `true` if any package has non-null `transport`, non-null `transport.type`, and `transport.type.getValue().equalsIgnoreCase(filterType)` for any filter value; update `matches()` to call it when `filter.getPackageTransportTypes()` is non-empty; update `hasActiveCriteria()` to also return `true` when `packageTransportTypes` is non-empty; rename `getRemoteTypes()` → `getRemoteTransportTypes()` references in existing `matchesRemoteTypes` call in `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/service/McpServerFilter.java`
+- [x] T003 [P] [US1] Rename `@RequestParam List<String> remoteTypes` → `remoteTransportTypes` with updated `@Parameter(description = "Remote transport types to filter by (OR logic). Renamed from remoteTypes. Values: sse, streamable-http")`; add `@Parameter(description = "Package transport types to filter by (OR logic). Values: stdio, streamable-http, sse") @RequestParam(required = false) List<String> packageTransportTypes`; update `buildFilter()` method signature to accept `remoteTransportTypes` and `packageTransportTypes`; update `buildFilter()` null-check to include `packageTransportTypes`; update `ServerFilterDto.builder()` to use `.remoteTransportTypes(remoteTransportTypes)` and `.packageTransportTypes(packageTransportTypes)` in `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/controller/McpRegistryController.java`
 
-- [X] T011 [US3] Add pagination-specific test scenarios to `McpRegistryServiceTest`: scan limit reached with upstream remaining returns nextCursor for continuation, caller provides cursor and scanning resumes from correct upstream position, upstream exhausted returns null nextCursor, partial page returned when scan limit hit (fewer results than limit), second request with cursor returns non-overlapping results. File: `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpRegistryServiceTest.java`
-- [X] T012 [US3] Add pagination controller test scenarios: GET with cursor param and filter params passes both to service, response metadata includes nextCursor when more results exist, response metadata has null nextCursor when upstream exhausted. File: `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/web/controller/McpRegistryControllerTest.java`
-
-**Checkpoint**: Paginated browsing through filtered results works seamlessly
+**Checkpoint**: US1 is fully functional — new filter dimension wired through DTO → predicate → controller.
 
 ---
 
-## Phase 5: User Story 4 — Configurable Maximum Page Scan Limit (Priority: P3)
+## Phase 4: User Story 2 — Combine Multiple Filters (Priority: P1)
 
-**Goal**: Operators can control how many upstream pages the system scans per request via the `MCP_REGISTRY_MAX_PAGES_TO_SCAN` environment variable.
+**Goal**: Verify AND-across-dimensions logic correctly applies `packageTransportTypes` alongside the existing three filter dimensions. No new source code required — this phase covers test tasks only, since the AND logic already works for any filter field added to `McpServerFilter`.
 
-**Independent Test**: Configure a low scan limit (e.g., 2), apply a rare filter, verify the system stops after the configured number of pages.
+**Independent Test**: `GET /api/v1/mcp-registry/servers?remoteTransportTypes=sse&packageRegistryTypes=npm&packageTransportTypes=stdio` returns only servers satisfying all three criteria simultaneously.
 
-**Depends on**: Phase 3 (scanning loop must exist)
+### Tests for User Story 2
 
-### Implementation
+- [x] T004 [P] [US2] In `McpServerFilterTest`: (a) rename all `.remoteTypes(...)` builder calls → `.remoteTransportTypes(...)`; (b) add helper `pkgWithTransport(LocalTransportType type)` returning `Package.builder().registryType(PackageRegistryType.NPM).transport(LocalTransport.builder().type(type).build()).build()`; (c) add test cases: `shouldMatchSinglePackageTransportType`, `shouldMatchPackageTransportTypeCaseInsensitive` (filter "STDIO", transport `LocalTransportType.STDIO`), `shouldMatchMultiValuePackageTransportTypeOrLogic` (filter ["stdio","sse"], server has stdio), `shouldNotMatchPackageTransportType_whenNoMatch`, `shouldNotMatchPackageTransportType_whenPackagesNull`, `shouldNotMatchPackageTransportType_whenPackagesEmpty`, `shouldNotMatchPackageTransportType_whenTransportIsNull` (package with `transport = null`); (d) update `shouldMatchAll_whenFilterHasEmptyLists` and `shouldReturnFalse_whenAllCriteriaEmpty` to include `packageTransportTypes(Collections.emptyList())`; (e) add `shouldReturnTrue_whenPackageTransportTypesPresent`; (f) add combined AND test `shouldMatchCombinedFilters_remoteTransportAndPackageTransportTypes` (server with SSE remote AND stdio-transport package); (g) add independent cross-package test `shouldMatchCombinedFilters_packageRegistryAndPackageTransportTypes_independentEvaluation` (OCI package + different package with streamable-http transport) in `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpServerFilterTest.java`
+- [x] T005 [P] [US2] In `McpRegistryControllerTest`: (a) rename all `.param("remoteTypes", ...)` → `.param("remoteTransportTypes", ...)`; (b) update all captured `ServerFilterDto` assertions from `getRemoteTypes()` → `getRemoteTransportTypes()`; (c) add test `getServers_shouldPassPackageTransportTypesFilter_whenParamProvided` — performs `GET /api/v1/mcp-registry/servers` with `.param("packageTransportTypes", "stdio")`, captures the `ServersRequestDto` argument passed to `mcpRegistryService.getServers()`, asserts `filter.getPackageTransportTypes()` equals `List.of("stdio")`; (d) verify `buildFilter` returns `null` when `remoteTransportTypes`, `packageRegistryTypes`, `packageTransportTypes`, and `repositoryExists` are all absent in `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/web/controller/McpRegistryControllerTest.java`
 
-- [X] T013 [US4] Add scan-limit-specific test scenarios to `McpRegistryServiceTest`: configured limit of 2 stops after 2 upstream pages regardless of results collected, default limit (5) is used when not explicitly configured, scan limit of 1 fetches exactly one upstream page. File: `src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpRegistryServiceTest.java`
-
-**Checkpoint**: Scan limit is configurable and bounded
+**Checkpoint**: US1 and US2 fully covered — all renamed references updated, all new test cases pass.
 
 ---
 
-## Phase 6: Polish & Cross-Cutting Concerns
+## Phase 5: Polish & Cross-Cutting Concerns
 
-**Purpose**: Documentation, API annotations, and quality verification
+**Purpose**: Documentation accuracy, code style, and full test suite validation.
 
-- [X] T014 [P] Add OpenAPI `@Operation` and `@Parameter` annotations for new filter query params (`remoteTypes`, `packageRegistryTypes`, `repositoryExists`) on the GET endpoint in `src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/controller/McpRegistryController.java`
-- [X] T015 [P] Update `docs/configuration.md` — add row for `app.mcp-registry.max-pages-to-scan` / `MCP_REGISTRY_MAX_PAGES_TO_SCAN` with default `5` and description
-- [X] T016 Run `./gradlew checkstyleMain checkstyleTest` and fix any violations
-- [X] T017 Run `./gradlew testFast` to verify all tests pass
+- [x] T006 [P] Verify `docs/configuration.md` has an accurate entry for `MCP_REGISTRY_MAX_PAGES_TO_SCAN` / `app.mcp-registry.max-pages-to-scan` with default value `25` — add or update if missing or stale in `docs/configuration.md`
+- [x] T007 Run `./gradlew checkstyleMain checkstyleTest` and fix any Google Java Style / 180-char line violations introduced by T001–T003
+- [x] T008 Run `./gradlew testFast` and confirm all tests pass (depends on T004, T005, T007)
 
 ---
 
@@ -102,81 +80,65 @@
 
 ### Phase Dependencies
 
-- **Setup (Phase 1)**: No dependencies — can start immediately
-- **Foundational (Phase 2)**: Depends on T001 (ServerFilterDto) from Setup — BLOCKS all user stories
-- **US1+US2 (Phase 3)**: Depends on Phase 2 completion (McpServerFilter ready)
-- **US3 (Phase 4)**: Depends on Phase 3 (scanning loop must exist to test pagination)
-- **US4 (Phase 5)**: Depends on Phase 3 (scanning loop must exist to test scan limits)
-- **Polish (Phase 6)**: Depends on all user stories being complete
+- **Phase 1–2 (Setup + Foundational)**: Start immediately; T001 must complete before T002/T003
+- **Phase 3 (US1)**: T002 and T003 in parallel after T001
+- **Phase 4 (US2 Tests)**: T004 depends on T002; T005 depends on T003; T004 and T005 run in parallel
+- **Phase 5 (Polish)**: T006 is independent; T007 after T001–T003; T008 after T004, T005, T007
 
-### User Story Dependencies
+### User Story Coverage
 
-- **US1+US2 (P1)**: Can start after Foundational (Phase 2) — no dependencies on other stories
-- **US3 (P2)**: Depends on US1+US2 — pagination is a property of the scanning loop
-- **US4 (P3)**: Depends on US1+US2 — scan limit is a property of the scanning loop
-- **US3 and US4**: Can run in parallel with each other (both only add tests to existing code)
-
-### Within Each Phase
-
-- DTOs before services
-- Services before controllers
-- Implementation before tests (tests validate the implementation)
-- Core logic before integration tests
+| Story | Priority | Status | Tasks |
+|-------|----------|--------|-------|
+| US1 — Filter by properties | P1 | New work | T001, T002, T003 |
+| US2 — Combine multiple filters | P1 | Tested by Phase 4 | T004, T005 |
+| US3 — Paginate filtered results | P2 | Already implemented | — |
+| US4 — Configurable scan limit | P3 | Already implemented | — |
 
 ### Parallel Opportunities
 
-- T002, T003, T004 can all run in parallel (different files, no dependencies)
-- T014, T015 can run in parallel (different files)
-- Phase 4 (US3) and Phase 5 (US4) can run in parallel (both add tests to existing code)
+- **T002 and T003** run in parallel after T001 (different files: service vs. controller)
+- **T004 and T005** run in parallel (different test files)
+- **T006** runs at any time (independent docs update)
 
 ---
 
-## Parallel Example: Phase 1 Setup
+## Parallel Example: Phase 3
 
 ```
-# These three tasks can run in parallel after T001:
-Task T002: Add filter field to ServersRequestDto.java
-Task T003: Add maxPagesToScan to McpRegistryProperties.java + application.yml
-Task T004: Create test JSON fixtures
+# After T001 (ServerFilterDto) compiles:
+Task T002: McpServerFilter.java — add packageTransportTypes logic, rename remoteTypes ref
+Task T003: McpRegistryController.java — rename remoteTypes param, add packageTransportTypes param
 ```
 
-## Parallel Example: Phase 3 US1+US2
+## Parallel Example: Phase 4
 
 ```
-# After T007 (service) is complete:
-Task T008: Update controller (different file from T007)
-Task T009: Create service unit tests (test file, different from T007)
-# After T008:
-Task T010: Create controller tests
+# After T001 (and T002 for T004, T003 for T005):
+Task T004: McpServerFilterTest.java — rename refs, add packageTransportTypes test cases
+Task T005: McpRegistryControllerTest.java — rename refs, add packageTransportTypes param test
 ```
 
 ---
 
 ## Implementation Strategy
 
-### MVP First (User Story 1+2 Only)
+### MVP (User Story 1 only)
 
-1. Complete Phase 1: Setup (DTOs, config, fixtures)
-2. Complete Phase 2: Foundational (McpServerFilter)
-3. Complete Phase 3: US1+US2 (scanning loop, controller, tests)
-4. **STOP and VALIDATE**: Test filtering via GET and POST endpoints independently
-5. Deploy/demo if ready — filtering and combining work end-to-end
+1. Complete Phase 2: T001 — DTO rename + new field
+2. Complete Phase 3: T002 + T003 in parallel — filter logic and controller
+3. **STOP and VALIDATE**: `GET /api/v1/mcp-registry/servers?packageTransportTypes=stdio` works; `remoteTransportTypes` param accepted; POST body `filter.packageTransportTypes` passes through
+4. Continue with Phase 4 (tests) + Phase 5 (polish)
 
 ### Incremental Delivery
 
-1. Setup + Foundational → Foundation ready
-2. Add US1+US2 → Test filtering and combining → Deploy (MVP!)
-3. Add US3 → Test pagination through filtered results → Deploy
-4. Add US4 → Test configurable scan limit → Deploy
-5. Polish → OpenAPI docs, configuration docs, checkstyle → Final release
+US3 (pagination) and US4 (configurable limit) are already fully implemented. This feature is a single cohesive increment: rename + add one filter dimension. Deliver as one PR.
 
 ---
 
 ## Notes
 
-- [P] tasks = different files, no dependencies
-- [Story] label maps task to specific user story for traceability
-- US1 and US2 are combined in Phase 3 because the filter model inherently supports both single and combined filters — they cannot be implemented separately
-- US3 (pagination) and US4 (scan limit) are testing phases — the underlying code is already part of the scanning loop in Phase 3
-- Commit after each task or logical group
-- Stop at any checkpoint to validate story independently
+- [P] tasks = different files, no dependency on an incomplete task in the same phase
+- US3 and US4 are already implemented and tested — `McpRegistryService` and `McpRegistryProperties` need no changes
+- The rename `remoteTypes` → `remoteTransportTypes` is a **breaking change** for any existing API callers using the old GET query param — note in release notes/changelog
+- `packageTransportTypes` and `packageRegistryTypes` use independent OR evaluation across all packages on a server (no co-location requirement — confirmed clarification 2026-04-02)
+- Null transport on a `Package` means that package does not match `packageTransportTypes` and is simply skipped; the server matches only if another of its packages has a non-null matching transport

--- a/src/main/java/com/epam/aidial/deployment/manager/registry/mcp/service/McpServerFilter.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/registry/mcp/service/McpServerFilter.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.deployment.manager.registry.mcp.service;
 
 import com.epam.aidial.deployment.manager.configuration.logging.LogExecution;
+import com.epam.aidial.deployment.manager.registry.mcp.model.LocalTransport;
 import com.epam.aidial.deployment.manager.registry.mcp.model.Package;
 import com.epam.aidial.deployment.manager.registry.mcp.model.RemoteTransport;
 import com.epam.aidial.deployment.manager.registry.mcp.web.dto.ServerFilterDto;
@@ -28,14 +29,20 @@ public class McpServerFilter {
             return false;
         }
 
-        if (CollectionUtils.isNotEmpty(filter.getRemoteTypes())) {
-            if (!matchesRemoteTypes(server.getRemotes(), filter.getRemoteTypes())) {
+        if (CollectionUtils.isNotEmpty(filter.getRemoteTransportTypes())) {
+            if (!matchesRemoteTypes(server.getRemotes(), filter.getRemoteTransportTypes())) {
                 return false;
             }
         }
 
         if (CollectionUtils.isNotEmpty(filter.getPackageRegistryTypes())) {
             if (!matchesPackageRegistryTypes(server.getPackages(), filter.getPackageRegistryTypes())) {
+                return false;
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(filter.getPackageTransportTypes())) {
+            if (!matchesPackageTransportTypes(server.getPackages(), filter.getPackageTransportTypes())) {
                 return false;
             }
         }
@@ -57,8 +64,9 @@ public class McpServerFilter {
         if (filter == null) {
             return false;
         }
-        return CollectionUtils.isNotEmpty(filter.getRemoteTypes())
+        return CollectionUtils.isNotEmpty(filter.getRemoteTransportTypes())
                 || CollectionUtils.isNotEmpty(filter.getPackageRegistryTypes())
+                || CollectionUtils.isNotEmpty(filter.getPackageTransportTypes())
                 || filter.getRepositoryExists() != null;
     }
 
@@ -78,5 +86,18 @@ public class McpServerFilter {
         return packages.stream()
                 .anyMatch(pkg -> pkg.getRegistryType() != null
                         && filterTypes.stream().anyMatch(ft -> ft.equalsIgnoreCase(pkg.getRegistryType().getValue())));
+    }
+
+    private boolean matchesPackageTransportTypes(List<Package> packages, List<String> filterTypes) {
+        if (CollectionUtils.isEmpty(packages)) {
+            return false;
+        }
+        return packages.stream()
+                .anyMatch(pkg -> {
+                    LocalTransport transport = pkg.getTransport();
+                    return transport != null
+                            && transport.getType() != null
+                            && filterTypes.stream().anyMatch(ft -> ft.equalsIgnoreCase(transport.getType().getValue()));
+                });
     }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/controller/McpRegistryController.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/controller/McpRegistryController.java
@@ -45,13 +45,15 @@ public class McpRegistryController {
             @RequestParam(required = false) String updatedSince,
             @RequestParam(required = false) String version,
             @Parameter(description = "Remote transport types to filter by (OR logic). Values: sse, streamable-http")
-            @RequestParam(required = false) List<String> remoteTypes,
+            @RequestParam(required = false) List<String> remoteTransportTypes,
             @Parameter(description = "Package registry types to filter by (OR logic). Values: npm, pypi, oci, nuget, mcpb")
             @RequestParam(required = false) List<String> packageRegistryTypes,
+            @Parameter(description = "Package transport types to filter by (OR logic). Values: stdio, streamable-http, sse")
+            @RequestParam(required = false) List<String> packageTransportTypes,
             @Parameter(description = "Filter by repository existence. true = only servers with repository, false = only without")
             @RequestParam(required = false) Boolean repositoryExists
     ) {
-        var filter = buildFilter(remoteTypes, packageRegistryTypes, repositoryExists);
+        var filter = buildFilter(remoteTransportTypes, packageRegistryTypes, packageTransportTypes, repositoryExists);
         var request = ServersRequestDto.builder()
                 .cursor(cursor)
                 .limit(limit)
@@ -100,15 +102,18 @@ public class McpRegistryController {
         return mcpRegistryService.getServerVersions(serverName);
     }
 
-    private static ServerFilterDto buildFilter(List<String> remoteTypes,
+    private static ServerFilterDto buildFilter(List<String> remoteTransportTypes,
                                                List<String> packageRegistryTypes,
+                                               List<String> packageTransportTypes,
                                                Boolean repositoryExists) {
-        if (remoteTypes == null && packageRegistryTypes == null && repositoryExists == null) {
+        if (remoteTransportTypes == null && packageRegistryTypes == null
+                && packageTransportTypes == null && repositoryExists == null) {
             return null;
         }
         return ServerFilterDto.builder()
-                .remoteTypes(remoteTypes)
+                .remoteTransportTypes(remoteTransportTypes)
                 .packageRegistryTypes(packageRegistryTypes)
+                .packageTransportTypes(packageTransportTypes)
                 .repositoryExists(repositoryExists)
                 .build();
     }

--- a/src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/dto/ServerFilterDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/registry/mcp/web/dto/ServerFilterDto.java
@@ -18,13 +18,20 @@ public class ServerFilterDto {
      * Remote transport types to match (OR logic). Values: "streamable-http", "sse".
      */
     @Nullable
-    private List<String> remoteTypes;
+    private List<String> remoteTransportTypes;
 
     /**
      * Package registry types to match (OR logic). Values: "npm", "pypi", "oci", "nuget", "mcpb".
      */
     @Nullable
     private List<String> packageRegistryTypes;
+
+    /**
+     * Package transport types to match (OR logic). Values: "stdio", "streamable-http", "sse".
+     * Matched case-insensitively against Package.transport.type. A package with null transport does not match.
+     */
+    @Nullable
+    private List<String> packageTransportTypes;
 
     /**
      * If true, match servers with non-null repository. If false, match servers with null repository.

--- a/src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpRegistryServiceTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpRegistryServiceTest.java
@@ -80,7 +80,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldReturnOnlyMatchingServers_whenSingleFilterApplied() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(5);
 
@@ -103,7 +103,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldScanMultiplePages_whenFirstPageHasNoMatches() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(5);
 
@@ -126,7 +126,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldCollectAllMatchesFromCurrentPage_whenPageSizeExceeded() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(2).filter(filter).build();
         stubScanLimit(5);
 
@@ -150,7 +150,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldForwardSearchParam_whenBackendFilterAlsoActive() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).search("myserver").filter(filter).build();
         stubScanLimit(5);
 
@@ -173,7 +173,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldReturnPartialResults_whenErrorMidScanWithCollectedResults() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(5);
 
@@ -194,7 +194,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldPropagateException_whenErrorMidScanWithNoResults() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(5);
 
@@ -213,7 +213,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldPropagateException_whenFirstPageFails() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(5);
 
@@ -230,7 +230,7 @@ class McpRegistryServiceTest {
     @Test
     void shouldApplyAndLogicAcrossFilterDimensions() {
         var filter = ServerFilterDto.builder()
-                .remoteTypes(List.of("sse"))
+                .remoteTransportTypes(List.of("sse"))
                 .packageRegistryTypes(List.of("npm"))
                 .build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
@@ -254,7 +254,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldReturnNextCursor_whenScanLimitReachedWithUpstreamRemaining() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(2);
 
@@ -276,7 +276,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldResumeScanningFromCursor() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).cursor("cursor1").filter(filter).build();
         stubScanLimit(5);
 
@@ -298,7 +298,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldReturnNullCursor_whenUpstreamExhausted() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(5);
 
@@ -316,7 +316,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldReturnPartialPage_whenScanLimitHit() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(10).filter(filter).build();
         stubScanLimit(1);
 
@@ -339,7 +339,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldStopAfterConfiguredScanLimit() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(2);
 
@@ -359,7 +359,7 @@ class McpRegistryServiceTest {
 
     @Test
     void shouldFetchExactlyOnePage_whenScanLimitIsOne() {
-        var filter = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var filter = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         var request = ServersRequestDto.builder().limit(100).filter(filter).build();
         stubScanLimit(1);
 

--- a/src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpServerFilterTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/mcpregistry/service/McpServerFilterTest.java
@@ -1,5 +1,7 @@
 package com.epam.aidial.deployment.manager.mcpregistry.service;
 
+import com.epam.aidial.deployment.manager.registry.mcp.model.LocalTransport;
+import com.epam.aidial.deployment.manager.registry.mcp.model.LocalTransportType;
 import com.epam.aidial.deployment.manager.registry.mcp.model.Package;
 import com.epam.aidial.deployment.manager.registry.mcp.model.PackageRegistryType;
 import com.epam.aidial.deployment.manager.registry.mcp.model.RemoteTransport;
@@ -24,42 +26,42 @@ class McpServerFilterTest {
     @Test
     void shouldMatchSingleRemoteType() {
         var server = serverWith(List.of(remote("sse")), null, null);
-        var criteria = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var criteria = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         assertThat(filter.matches(server, criteria)).isTrue();
     }
 
     @Test
     void shouldMatchRemoteTypeCaseInsensitive() {
         var server = serverWith(List.of(remote("SSE")), null, null);
-        var criteria = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var criteria = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         assertThat(filter.matches(server, criteria)).isTrue();
     }
 
     @Test
     void shouldMatchMultiValueRemoteTypeOrLogic() {
         var server = serverWith(List.of(remote("sse")), null, null);
-        var criteria = ServerFilterDto.builder().remoteTypes(List.of("sse", "streamable-http")).build();
+        var criteria = ServerFilterDto.builder().remoteTransportTypes(List.of("sse", "streamable-http")).build();
         assertThat(filter.matches(server, criteria)).isTrue();
     }
 
     @Test
     void shouldNotMatchRemoteType_whenNoMatch() {
         var server = serverWith(List.of(remote("sse")), null, null);
-        var criteria = ServerFilterDto.builder().remoteTypes(List.of("streamable-http")).build();
+        var criteria = ServerFilterDto.builder().remoteTransportTypes(List.of("streamable-http")).build();
         assertThat(filter.matches(server, criteria)).isFalse();
     }
 
     @Test
     void shouldNotMatchRemoteType_whenRemotesNull() {
         var server = serverWith(null, null, null);
-        var criteria = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var criteria = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         assertThat(filter.matches(server, criteria)).isFalse();
     }
 
     @Test
     void shouldNotMatchRemoteType_whenRemotesEmpty() {
         var server = serverWith(Collections.emptyList(), null, null);
-        var criteria = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var criteria = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         assertThat(filter.matches(server, criteria)).isFalse();
     }
 
@@ -137,6 +139,57 @@ class McpServerFilterTest {
         assertThat(filter.matches(server, criteria)).isFalse();
     }
 
+    // --- Package transport type matching ---
+
+    @Test
+    void shouldMatchSinglePackageTransportType() {
+        var server = serverWith(null, List.of(pkgWithTransport(LocalTransportType.STDIO)), null);
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("stdio")).build();
+        assertThat(filter.matches(server, criteria)).isTrue();
+    }
+
+    @Test
+    void shouldMatchPackageTransportTypeCaseInsensitive() {
+        var server = serverWith(null, List.of(pkgWithTransport(LocalTransportType.STDIO)), null);
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("STDIO")).build();
+        assertThat(filter.matches(server, criteria)).isTrue();
+    }
+
+    @Test
+    void shouldMatchMultiValuePackageTransportTypeOrLogic() {
+        var server = serverWith(null, List.of(pkgWithTransport(LocalTransportType.STDIO)), null);
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("stdio", "sse")).build();
+        assertThat(filter.matches(server, criteria)).isTrue();
+    }
+
+    @Test
+    void shouldNotMatchPackageTransportType_whenNoMatch() {
+        var server = serverWith(null, List.of(pkgWithTransport(LocalTransportType.STDIO)), null);
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("streamable-http")).build();
+        assertThat(filter.matches(server, criteria)).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchPackageTransportType_whenPackagesNull() {
+        var server = serverWith(null, null, null);
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("stdio")).build();
+        assertThat(filter.matches(server, criteria)).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchPackageTransportType_whenPackagesEmpty() {
+        var server = serverWith(null, Collections.emptyList(), null);
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("stdio")).build();
+        assertThat(filter.matches(server, criteria)).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchPackageTransportType_whenTransportIsNull() {
+        var server = serverWith(null, List.of(pkg(PackageRegistryType.NPM)), null);
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("stdio")).build();
+        assertThat(filter.matches(server, criteria)).isFalse();
+    }
+
     // --- Null/empty filter (match all) ---
 
     @Test
@@ -149,8 +202,9 @@ class McpServerFilterTest {
     void shouldMatchAll_whenFilterHasEmptyLists() {
         var server = serverWith(null, null, null);
         var criteria = ServerFilterDto.builder()
-                .remoteTypes(Collections.emptyList())
+                .remoteTransportTypes(Collections.emptyList())
                 .packageRegistryTypes(Collections.emptyList())
+                .packageTransportTypes(Collections.emptyList())
                 .build();
         assertThat(filter.matches(server, criteria)).isTrue();
     }
@@ -165,7 +219,7 @@ class McpServerFilterTest {
                 Repository.builder().url("https://github.com/x").build()
         );
         var criteria = ServerFilterDto.builder()
-                .remoteTypes(List.of("sse"))
+                .remoteTransportTypes(List.of("sse"))
                 .packageRegistryTypes(List.of("npm"))
                 .repositoryExists(true)
                 .build();
@@ -180,11 +234,57 @@ class McpServerFilterTest {
                 null // no repository
         );
         var criteria = ServerFilterDto.builder()
-                .remoteTypes(List.of("sse"))
+                .remoteTransportTypes(List.of("sse"))
                 .packageRegistryTypes(List.of("npm"))
                 .repositoryExists(true)
                 .build();
         assertThat(filter.matches(server, criteria)).isFalse();
+    }
+
+    @Test
+    void shouldMatchCombinedFilters_remoteTransportAndPackageTransportTypes() {
+        var server = serverWith(
+                List.of(remote("sse")),
+                List.of(pkgWithTransport(LocalTransportType.STDIO)),
+                null
+        );
+        var criteria = ServerFilterDto.builder()
+                .remoteTransportTypes(List.of("sse"))
+                .packageTransportTypes(List.of("stdio"))
+                .build();
+        assertThat(filter.matches(server, criteria)).isTrue();
+    }
+
+    @Test
+    void shouldMatchCombinedFilters_packageRegistryAndPackageTransportTypes_independentEvaluation() {
+        // OCI package (no transport) + NPM package with streamable-http transport — different packages
+        var ociPkg = pkg(PackageRegistryType.OCI);
+        var npmWithTransport = Package.builder()
+                .registryType(PackageRegistryType.NPM)
+                .transport(LocalTransport.builder().type(LocalTransportType.STREAMABLE_HTTP).build())
+                .identifier("npm-pkg")
+                .build();
+        var server = serverWith(null, List.of(ociPkg, npmWithTransport), null);
+        var criteria = ServerFilterDto.builder()
+                .packageRegistryTypes(List.of("oci"))
+                .packageTransportTypes(List.of("streamable-http"))
+                .build();
+        assertThat(filter.matches(server, criteria)).isTrue();
+    }
+
+    @Test
+    void shouldMatchServer_withOciPackageAndStreamableHttpTransport() {
+        var ociStreamableHttpPkg = Package.builder()
+                .registryType(PackageRegistryType.OCI)
+                .identifier("oci-pkg")
+                .transport(LocalTransport.builder().type(LocalTransportType.STREAMABLE_HTTP).build())
+                .build();
+        var server = serverWith(null, List.of(ociStreamableHttpPkg), null);
+        var criteria = ServerFilterDto.builder()
+                .packageRegistryTypes(List.of("oci"))
+                .packageTransportTypes(List.of("streamable-http"))
+                .build();
+        assertThat(filter.matches(server, criteria)).isTrue();
     }
 
     // --- hasActiveCriteria ---
@@ -197,21 +297,28 @@ class McpServerFilterTest {
     @Test
     void shouldReturnFalse_whenAllCriteriaEmpty() {
         var criteria = ServerFilterDto.builder()
-                .remoteTypes(Collections.emptyList())
+                .remoteTransportTypes(Collections.emptyList())
                 .packageRegistryTypes(Collections.emptyList())
+                .packageTransportTypes(Collections.emptyList())
                 .build();
         assertThat(filter.hasActiveCriteria(criteria)).isFalse();
     }
 
     @Test
     void shouldReturnTrue_whenRemoteTypesPresent() {
-        var criteria = ServerFilterDto.builder().remoteTypes(List.of("sse")).build();
+        var criteria = ServerFilterDto.builder().remoteTransportTypes(List.of("sse")).build();
         assertThat(filter.hasActiveCriteria(criteria)).isTrue();
     }
 
     @Test
     void shouldReturnTrue_whenRepositoryExistsPresent() {
         var criteria = ServerFilterDto.builder().repositoryExists(true).build();
+        assertThat(filter.hasActiveCriteria(criteria)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrue_whenPackageTransportTypesPresent() {
+        var criteria = ServerFilterDto.builder().packageTransportTypes(List.of("stdio")).build();
         assertThat(filter.hasActiveCriteria(criteria)).isTrue();
     }
 
@@ -237,5 +344,13 @@ class McpServerFilterTest {
 
     private static Package pkg(PackageRegistryType registryType) {
         return Package.builder().registryType(registryType).identifier("test-pkg").build();
+    }
+
+    private static Package pkgWithTransport(LocalTransportType transportType) {
+        return Package.builder()
+                .registryType(PackageRegistryType.NPM)
+                .identifier("test-pkg")
+                .transport(LocalTransport.builder().type(transportType).build())
+                .build();
     }
 }

--- a/src/test/java/com/epam/aidial/deployment/manager/mcpregistry/web/controller/McpRegistryControllerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/mcpregistry/web/controller/McpRegistryControllerTest.java
@@ -187,18 +187,33 @@ class McpRegistryControllerTest extends AbstractControllerNoneSecureTest {
     // --- Filter param tests (T010, T012) ---
 
     @Test
-    void getServers_shouldPassRemoteTypesFilter() throws Exception {
+    void getServers_shouldPassRemoteTransportTypesFilter() throws Exception {
         var serviceResponse = emptyServerListResponse();
         when(mcpRegistryService.getServers(any())).thenReturn(serviceResponse);
 
         mockMvc.perform(get("/api/v1/mcp-registry/servers")
-                        .param("remoteTypes", "sse"))
+                        .param("remoteTransportTypes", "sse"))
                 .andExpect(status().isOk());
 
         var captor = forClass(ServersRequestDto.class);
         verify(mcpRegistryService).getServers(captor.capture());
         assertThat(captor.getValue().getFilter()).isNotNull();
-        assertThat(captor.getValue().getFilter().getRemoteTypes()).containsExactly("sse");
+        assertThat(captor.getValue().getFilter().getRemoteTransportTypes()).containsExactly("sse");
+    }
+
+    @Test
+    void getServers_shouldPassPackageTransportTypesFilter() throws Exception {
+        var serviceResponse = emptyServerListResponse();
+        when(mcpRegistryService.getServers(any())).thenReturn(serviceResponse);
+
+        mockMvc.perform(get("/api/v1/mcp-registry/servers")
+                        .param("packageTransportTypes", "stdio"))
+                .andExpect(status().isOk());
+
+        var captor = forClass(ServersRequestDto.class);
+        verify(mcpRegistryService).getServers(captor.capture());
+        assertThat(captor.getValue().getFilter()).isNotNull();
+        assertThat(captor.getValue().getFilter().getPackageTransportTypes()).containsExactly("stdio");
     }
 
     @Test
@@ -237,7 +252,7 @@ class McpRegistryControllerTest extends AbstractControllerNoneSecureTest {
         when(mcpRegistryService.getServers(any())).thenReturn(serviceResponse);
 
         mockMvc.perform(get("/api/v1/mcp-registry/servers")
-                        .param("remoteTypes", "sse")
+                        .param("remoteTransportTypes", "sse")
                         .param("packageRegistryTypes", "npm")
                         .param("repositoryExists", "true"))
                 .andExpect(status().isOk());
@@ -246,7 +261,7 @@ class McpRegistryControllerTest extends AbstractControllerNoneSecureTest {
         verify(mcpRegistryService).getServers(captor.capture());
         var filter = captor.getValue().getFilter();
         assertThat(filter).isNotNull();
-        assertThat(filter.getRemoteTypes()).containsExactly("sse");
+        assertThat(filter.getRemoteTransportTypes()).containsExactly("sse");
         assertThat(filter.getPackageRegistryTypes()).containsExactly("npm");
         assertThat(filter.getRepositoryExists()).isTrue();
     }
@@ -273,8 +288,9 @@ class McpRegistryControllerTest extends AbstractControllerNoneSecureTest {
                 {
                     "limit": 50,
                     "filter": {
-                        "remoteTypes": ["sse", "streamable-http"],
+                        "remoteTransportTypes": ["sse", "streamable-http"],
                         "packageRegistryTypes": ["npm"],
+                        "packageTransportTypes": ["stdio"],
                         "repositoryExists": true
                     }
                 }
@@ -289,8 +305,9 @@ class McpRegistryControllerTest extends AbstractControllerNoneSecureTest {
         verify(mcpRegistryService).getServers(captor.capture());
         var filter = captor.getValue().getFilter();
         assertThat(filter).isNotNull();
-        assertThat(filter.getRemoteTypes()).containsExactly("sse", "streamable-http");
+        assertThat(filter.getRemoteTransportTypes()).containsExactly("sse", "streamable-http");
         assertThat(filter.getPackageRegistryTypes()).containsExactly("npm");
+        assertThat(filter.getPackageTransportTypes()).containsExactly("stdio");
         assertThat(filter.getRepositoryExists()).isTrue();
     }
 
@@ -303,7 +320,7 @@ class McpRegistryControllerTest extends AbstractControllerNoneSecureTest {
         when(mcpRegistryService.getServers(any())).thenReturn(serviceResponse);
 
         mockMvc.perform(get("/api/v1/mcp-registry/servers")
-                        .param("remoteTypes", "sse"))
+                        .param("remoteTransportTypes", "sse"))
                 .andExpect(status().isOk())
                 .andExpect(content().json("{\"metadata\":{\"nextCursor\":\"cursor-abc\"}}", JsonCompareMode.LENIENT));
     }
@@ -315,7 +332,7 @@ class McpRegistryControllerTest extends AbstractControllerNoneSecureTest {
 
         mockMvc.perform(get("/api/v1/mcp-registry/servers")
                         .param("cursor", "cursor-abc")
-                        .param("remoteTypes", "sse"))
+                        .param("remoteTransportTypes", "sse"))
                 .andExpect(status().isOk());
 
         var captor = forClass(ServersRequestDto.class);


### PR DESCRIPTION
add packageTransportTypes filter and rename remoteTypes to remo)teTransportTypes (#009)

- Rename ServerFilterDto.remoteTypes → remoteTransportTypes
- Add ServerFilterDto.packageTransportTypes (OR logic, case-insensitive)
- Wire new filter dimension through McpServerFilter and McpRegistryController
- Update all tests: renamed refs + new packageTransportTypes test cases


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.