### PR TITLE
fix: handle unrecoverable K8s errors on deploy/undeploy

### DIFF
--- a/specs/deployments/spec.md
+++ b/specs/deployments/spec.md
@@ -160,6 +160,14 @@ Status: **Implemented**
 - **WHEN** `POST /api/v1/deployments/{id}/deploy` is called on a `CRASHED` deployment
 - **THEN** Kubernetes resources are updated and status transitions to `PENDING`
 
+#### Scenario: Unrecoverable Kubernetes error on deploy
+- **WHEN** a deploy operation encounters an unrecoverable Kubernetes API error (HTTP 404, 401, or 403)
+- **THEN** the deployment is marked as `STOPPED` and a `DeploymentException` is thrown. Disposable resources are marked for cleanup.
+
+#### Scenario: Transient Kubernetes error on deploy
+- **WHEN** a deploy operation encounters a transient Kubernetes API error (e.g., HTTP 500)
+- **THEN** a `DeploymentException` is thrown but the deployment status is **not** changed to `STOPPED`. Disposable resources are marked for cleanup.
+
 ### Requirement: Deactivate a deployment (undeploy)
 The system SHALL remove Kubernetes resources for a deployment while preserving its configuration record. Status transitions to `STOPPING`, then `STOPPED`.
 
@@ -168,6 +176,10 @@ Status: **Implemented**
 #### Scenario: Successful undeploy
 - **WHEN** `POST /api/v1/deployments/{id}/undeploy` is called
 - **THEN** Kubernetes resources are removed and status transitions to `STOPPING`, eventually reaching `STOPPED`
+
+#### Scenario: Kubernetes 404 on resource deletion during undeploy
+- **WHEN** a Kubernetes resource (service, CiliumNetworkPolicy, etc.) returns HTTP 404 during deletion
+- **THEN** the error is treated as "already deleted" and the undeploy proceeds without failure
 
 ### Requirement: Deployment carries common base configuration
 All deployment types SHALL carry these fields:

--- a/src/main/java/com/epam/aidial/deployment/manager/kubernetes/AbstractK8sResourceClient.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/kubernetes/AbstractK8sResourceClient.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import lombok.extern.slf4j.Slf4j;
 
+import java.net.HttpURLConnection;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -116,6 +117,11 @@ public abstract class AbstractK8sResourceClient<T extends HasMetadata, L extends
                         getResourceName(), name, namespace);
             }
         } catch (KubernetesClientException e) {
+            if (e.getCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                log.warn("{} '{}' or its resource type not found in namespace '{}' (404). Treating as deleted.",
+                        getResourceName(), name, namespace);
+                return;
+            }
             log.warn("Failed to delete {} '{}' in namespace '{}': {} (Code: {})",
                     getResourceName(), name, namespace, e.getMessage(), e.getCode(), e);
             throw e;

--- a/src/main/java/com/epam/aidial/deployment/manager/kubernetes/K8sClient.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/kubernetes/K8sClient.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.net.HttpURLConnection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -217,7 +218,7 @@ public class K8sClient {
                     .delete();
             log.debug("CiliumNetworkPolicy '{}' successfully deleted.", name);
         } catch (KubernetesClientException e) {
-            if (e.getCode() == java.net.HttpURLConnection.HTTP_NOT_FOUND) {
+            if (e.getCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                 log.warn("CiliumNetworkPolicy '{}' or its CRD not found in namespace '{}' (404)."
                         + " Treating as deleted.", name, namespace);
                 return;

--- a/src/main/java/com/epam/aidial/deployment/manager/kubernetes/K8sClient.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/kubernetes/K8sClient.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -209,11 +210,20 @@ public class K8sClient {
 
     public void deleteCiliumNetworkPolicy(String namespace, String name) {
         log.debug("Deleting CiliumNetworkPolicy '{}' in namespace '{}'", name, namespace);
-        client.resources(CiliumNetworkPolicy.class)
-                .inNamespace(namespace)
-                .withName(name)
-                .delete();
-        log.debug("CiliumNetworkPolicy '{}' successfully deleted.", name);
+        try {
+            client.resources(CiliumNetworkPolicy.class)
+                    .inNamespace(namespace)
+                    .withName(name)
+                    .delete();
+            log.debug("CiliumNetworkPolicy '{}' successfully deleted.", name);
+        } catch (KubernetesClientException e) {
+            if (e.getCode() == java.net.HttpURLConnection.HTTP_NOT_FOUND) {
+                log.warn("CiliumNetworkPolicy '{}' or its CRD not found in namespace '{}' (404)."
+                        + " Treating as deleted.", name, namespace);
+                return;
+            }
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventList;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -45,6 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.net.HttpURLConnection;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -126,6 +128,11 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                         var errorMessage = "Failed to deploy service '%s'".formatted(id);
                         log.warn(errorMessage, e);
                         markDisposableResourcesForCleanup(id, namespace, deployment.getServiceName(), deployment.getServiceName());
+                        if (isUnrecoverableK8sError(e)) {
+                            log.warn("Unrecoverable Kubernetes error for deployment '{}' (HTTP {}). Marking as STOPPED.",
+                                    id, ((KubernetesClientException) e).getCode());
+                            deploymentRepository.updateStatusInNewTransaction(id, DeploymentStatus.STOPPED);
+                        }
                         throw new DeploymentException(errorMessage, e);
                     }
                 }
@@ -723,6 +730,16 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
         disposableResources.addAll(cnpDisposableResources);
 
         return disposableResources;
+    }
+
+    private static boolean isUnrecoverableK8sError(Exception e) {
+        if (e instanceof KubernetesClientException kce) {
+            int code = kce.getCode();
+            return code == HttpURLConnection.HTTP_NOT_FOUND
+                    || code == HttpURLConnection.HTTP_UNAUTHORIZED
+                    || code == HttpURLConnection.HTTP_FORBIDDEN;
+        }
+        return false;
     }
 
     private void createCiliumNetworkPolicy(String groupId, List<String> allowedDomains, Set<Integer> ports, String name) {

--- a/src/test/java/com/epam/aidial/deployment/manager/kubernetes/K8sClientTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/kubernetes/K8sClientTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.deployment.manager.kubernetes;
 
+import io.cilium.v2.CiliumNetworkPolicy;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -13,6 +14,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobList;
 import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -32,9 +34,11 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -42,6 +46,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("rawtypes")
 @ExtendWith(MockitoExtension.class)
 class K8sClientTest {
 
@@ -50,6 +55,7 @@ class K8sClientTest {
     private static final String SECRET_NAME = "test-secret";
     private static final String JOB_NAME = "test-job";
     private static final String POD_NAME = "test-pod";
+    private static final String CNP_NAME = "test-cnp";
     private static final long TIMEOUT_SEC = 60;
 
     @Mock
@@ -82,6 +88,12 @@ class K8sClientTest {
     private Resource<ConfigMap> configMapResource;
     @Mock
     private ScalableResource<Job> scalableJobResource;
+    @Mock
+    private MixedOperation cnpOperation;
+    @Mock
+    private NonNamespaceOperation namespacedCnpOperation;
+    @Mock
+    private Resource cnpResource;
 
     private K8sClient k8sClient;
 
@@ -442,6 +454,49 @@ class K8sClientTest {
         verify(v1BatchApiGroupDsl.jobs()).inNamespace(NAMESPACE);
         verify(namespacedJobOperation).withName(JOB_NAME);
         verify(scalableJobResource).delete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void deleteCiliumNetworkPolicy_shouldDeleteSuccessfully() {
+        // Given
+        when(kubernetesClient.resources(CiliumNetworkPolicy.class)).thenReturn(cnpOperation);
+        when(cnpOperation.inNamespace(NAMESPACE)).thenReturn(namespacedCnpOperation);
+        when(namespacedCnpOperation.withName(CNP_NAME)).thenReturn(cnpResource);
+
+        // When
+        k8sClient.deleteCiliumNetworkPolicy(NAMESPACE, CNP_NAME);
+
+        // Then
+        verify(cnpResource).delete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void deleteCiliumNetworkPolicy_shouldTreatNotFoundAsDeleted() {
+        // Given
+        when(kubernetesClient.resources(CiliumNetworkPolicy.class)).thenReturn(cnpOperation);
+        when(cnpOperation.inNamespace(NAMESPACE)).thenReturn(namespacedCnpOperation);
+        when(namespacedCnpOperation.withName(CNP_NAME)).thenReturn(cnpResource);
+        when(cnpResource.delete()).thenThrow(new KubernetesClientException("Not Found", 404, null));
+
+        // When — should not throw
+        assertThatCode(() -> k8sClient.deleteCiliumNetworkPolicy(NAMESPACE, CNP_NAME))
+                .doesNotThrowAnyException();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void deleteCiliumNetworkPolicy_shouldRethrowNon404KubernetesException() {
+        // Given
+        when(kubernetesClient.resources(CiliumNetworkPolicy.class)).thenReturn(cnpOperation);
+        when(cnpOperation.inNamespace(NAMESPACE)).thenReturn(namespacedCnpOperation);
+        when(namespacedCnpOperation.withName(CNP_NAME)).thenReturn(cnpResource);
+        when(cnpResource.delete()).thenThrow(new KubernetesClientException("Internal Server Error", 500, null));
+
+        // When & Then
+        assertThrows(KubernetesClientException.class,
+                () -> k8sClient.deleteCiliumNetworkPolicy(NAMESPACE, CNP_NAME));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/epam/aidial/deployment/manager/kubernetes/knative/K8sKnativeClientTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/kubernetes/knative/K8sKnativeClientTest.java
@@ -185,6 +185,28 @@ class K8sKnativeClientTest {
     }
 
     @Test
+    void deleteService_shouldTreatNotFoundAsDeleted() {
+        // Given
+        when(knativeClient.services()).thenReturn(knativeServiceOperation);
+        when(knativeServiceOperation.inNamespace(NAMESPACE)).thenReturn(namespacedKnativeServiceOperation);
+        when(namespacedKnativeServiceOperation.withName(SERVICE_NAME)).thenReturn(knativeServiceResource);
+        when(knativeServiceResource.withPropagationPolicy(any())).thenAnswer(invocation -> knativeServiceResource);
+        when(knativeServiceResource.withGracePeriod(0L)).thenAnswer(invocation -> knativeServiceResource);
+        when(knativeServiceResource.delete()).thenThrow(new KubernetesClientException("Not Found", 404, null));
+
+        // When — should not throw
+        k8sKnativeClient.deleteService(NAMESPACE, SERVICE_NAME);
+
+        // Then
+        verify(knativeClient).services();
+        verify(knativeServiceOperation).inNamespace(NAMESPACE);
+        verify(namespacedKnativeServiceOperation).withName(SERVICE_NAME);
+        verify(knativeServiceResource).withPropagationPolicy(eq(DeletionPropagation.FOREGROUND));
+        verify(knativeServiceResource).withGracePeriod(0L);
+        verify(knativeServiceResource).delete();
+    }
+
+    @Test
     void deleteService_shouldRethrowWhenKubernetesExceptionOccurs() {
         // Given
         when(knativeClient.services()).thenReturn(knativeServiceOperation);

--- a/src/test/java/com/epam/aidial/deployment/manager/kubernetes/nim/K8sNimClientTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/kubernetes/nim/K8sNimClientTest.java
@@ -175,6 +175,24 @@ class K8sNimClientTest {
     }
 
     @Test
+    void deleteService_shouldTreatNotFoundAsDeleted() {
+        // Given
+        when(nimClient.services()).thenReturn(nimServiceOperation);
+        when(nimServiceOperation.inNamespace(NAMESPACE)).thenReturn(namespacedNimServiceOperation);
+        when(namespacedNimServiceOperation.withName(SERVICE_NAME)).thenReturn(nimServiceResource);
+        when(nimServiceResource.delete()).thenThrow(new KubernetesClientException("Not Found", 404, null));
+
+        // When — should not throw
+        k8sNimClient.deleteService(NAMESPACE, SERVICE_NAME);
+
+        // Then
+        verify(nimClient).services();
+        verify(nimServiceOperation).inNamespace(NAMESPACE);
+        verify(namespacedNimServiceOperation).withName(SERVICE_NAME);
+        verify(nimServiceResource).delete();
+    }
+
+    @Test
     void deleteService_shouldReturnFalseWhenExceptionOccurs() {
         // Given
         when(nimClient.services()).thenReturn(nimServiceOperation);

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/NimDeploymentManagerTest.java
@@ -33,6 +33,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.junit.jupiter.api.AfterEach;
@@ -506,6 +507,139 @@ class NimDeploymentManagerTest {
                 .isInstanceOf(DeploymentException.class)
                 .hasMessageContaining("Failed to deploy service");
 
+        verify(disposableResourceManager).markNimServiceResourceForCleanup(eq(DEPLOYMENT_ID), eq(SERVICE_NAME), eq(NAMESPACE));
+    }
+
+    @Test
+    void deploy_shouldMarkStoppedOnUnrecoverableK8sErrorFromCreateService() {
+        // Given
+        Deployment deployment = createDeployment(DeploymentStatus.STOPPED);
+        NIMService serviceSpec = new NIMService();
+        serviceSpec.getMetadata().setName(SERVICE_NAME);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(nimManifestGenerator.serviceConfig(
+                eq(DEPLOYMENT_ID),
+                eq(SERVICE_NAME),
+                any(),
+                any(),
+                any(),
+                eq(IMAGE_NAME),
+                anyInt(),
+                any(),
+                any(),
+                any(Boolean.class),
+                any(),
+                any(),
+                any()
+        )).thenReturn(serviceSpec);
+        when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(false);
+        doThrow(new KubernetesClientException("Not Found", 404, null))
+                .when(k8sNimClient).createService(eq(NAMESPACE), any());
+
+        // When
+        nimDeploymentManager.deploy(DEPLOYMENT_ID);
+
+        var synchronizations = TransactionSynchronizationManager.getSynchronizations();
+        assertThatThrownBy(() -> {
+            for (TransactionSynchronization sync : synchronizations) {
+                sync.afterCommit();
+            }
+        })
+                .isInstanceOf(DeploymentException.class)
+                .hasMessageContaining("Failed to deploy service");
+
+        // Then
+        verify(deploymentRepository).updateStatusInNewTransaction(eq(DEPLOYMENT_ID), eq(DeploymentStatus.STOPPED));
+        verify(disposableResourceManager).markNimServiceResourceForCleanup(eq(DEPLOYMENT_ID), eq(SERVICE_NAME), eq(NAMESPACE));
+    }
+
+    @Test
+    void deploy_shouldMarkStoppedOnUnrecoverableK8sErrorFromCreateCiliumNetworkPolicy() {
+        // Given
+        Deployment deployment = createDeployment(DeploymentStatus.STOPPED);
+        NIMService serviceSpec = new NIMService();
+        serviceSpec.getMetadata().setName(SERVICE_NAME);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(nimManifestGenerator.serviceConfig(
+                eq(DEPLOYMENT_ID),
+                eq(SERVICE_NAME),
+                any(),
+                any(),
+                any(),
+                eq(IMAGE_NAME),
+                anyInt(),
+                any(),
+                any(),
+                any(Boolean.class),
+                any(),
+                any(),
+                any()
+        )).thenReturn(serviceSpec);
+        when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(true);
+        when(ciliumNetworkPolicyCreator.create(eq(NAMESPACE), anyString(), eq(SERVICE_NAME), anyList(), any())).thenReturn(ciliumNetworkPolicy);
+        doThrow(new KubernetesClientException("Forbidden", 403, null))
+                .when(k8sClient).createCiliumNetworkPolicy(eq(NAMESPACE), any());
+
+        // When
+        nimDeploymentManager.deploy(DEPLOYMENT_ID);
+
+        var synchronizations = TransactionSynchronizationManager.getSynchronizations();
+        assertThatThrownBy(() -> {
+            for (TransactionSynchronization sync : synchronizations) {
+                sync.afterCommit();
+            }
+        })
+                .isInstanceOf(DeploymentException.class)
+                .hasMessageContaining("Failed to deploy service");
+
+        // Then
+        verify(deploymentRepository).updateStatusInNewTransaction(eq(DEPLOYMENT_ID), eq(DeploymentStatus.STOPPED));
+        verify(disposableResourceManager).markNimServiceResourceForCleanup(eq(DEPLOYMENT_ID), eq(SERVICE_NAME), eq(NAMESPACE));
+    }
+
+    @Test
+    void deploy_shouldNotMarkStoppedOnTransientK8sError() {
+        // Given
+        Deployment deployment = createDeployment(DeploymentStatus.STOPPED);
+        NIMService serviceSpec = new NIMService();
+        serviceSpec.getMetadata().setName(SERVICE_NAME);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+        when(nimManifestGenerator.serviceConfig(
+                eq(DEPLOYMENT_ID),
+                eq(SERVICE_NAME),
+                any(),
+                any(),
+                any(),
+                eq(IMAGE_NAME),
+                anyInt(),
+                any(),
+                any(),
+                any(Boolean.class),
+                any(),
+                any(),
+                any()
+        )).thenReturn(serviceSpec);
+        when(ciliumNetworkPolicyCreator.isCiliumNetworkPoliciesEnabled()).thenReturn(false);
+        doThrow(new KubernetesClientException("Internal Server Error", 500, null))
+                .when(k8sNimClient).createService(eq(NAMESPACE), any());
+
+        // When
+        nimDeploymentManager.deploy(DEPLOYMENT_ID);
+
+        var synchronizations = TransactionSynchronizationManager.getSynchronizations();
+        assertThatThrownBy(() -> {
+            for (TransactionSynchronization sync : synchronizations) {
+                sync.afterCommit();
+            }
+        })
+                .isInstanceOf(DeploymentException.class)
+                .hasMessageContaining("Failed to deploy service");
+
+        // Then - should NOT update status to STOPPED for transient errors
+        verify(deploymentRepository, never()).updateStatusInNewTransaction(any(), any());
         verify(disposableResourceManager).markNimServiceResourceForCleanup(eq(DEPLOYMENT_ID), eq(SERVICE_NAME), eq(NAMESPACE));
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

- #241 
- #242 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

 - AbstractK8sResourceClient.deleteService(): 404 KubernetesClientException is now caught and treated as successful deletion instead of being re-thrown — covers the case where the CRD/operator has been removed from the cluster                                                                                                                 
- K8sClient.deleteCiliumNetworkPolicy(): Same 404-tolerant handling added, since the CiliumNetworkPolicy CRD may also be unavailable                                     
- AbstractDeploymentManager.deploy(): The afterCommit() catch block now inspects KubernetesClientException error codes. For unrecoverable errors (404 — CRD not installed, 401 — unauthorized, 403 — forbidden), the deployment is immediately transitioned to STOPPED via updateStatusInNewTransaction() instead of remaining stuck in  PENDING indefinitely. Transient errors (e.g., 500, 503) retain the existing behavior.                                                                                    
- Tests: Added 404-tolerance tests for Knative, NIM, and CiliumNetworkPolicy delete paths, plus a test confirming non-404 errors still propagate. Added unit tests for unrecoverable K8s errors from createService() (404) and createCiliumNetworkPolicy() (403) verifying the deployment is marked STOPPED, plus a test confirming transient errors (500) do not trigger the STOPPED transition.  

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.