### PR TITLE
fix: validate minReplicas is 0 when scaleToZeroDelaySeconds is set

### DIFF
--- a/specs/deployments/spec.md
+++ b/specs/deployments/spec.md
@@ -214,9 +214,9 @@ All deployment types SHALL carry these fields:
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `minReplicas` | int | Yes | Minimum replica count. `@Min(0)`. |
+| `minReplicas` | int | Yes | Minimum replica count. `@Min(0)`. Must be 0 when `scaleToZeroDelaySeconds` is set; must be > 0 when `scaleToZeroDelaySeconds` is not set. |
 | `maxReplicas` | int | Yes | Maximum replica count. `@Min(1)`. |
-| `scaleToZeroDelaySeconds` | Integer | No | Idle time (seconds) before scaling to zero. `@Min(1)`. |
+| `scaleToZeroDelaySeconds` | Integer | No | Idle time (seconds) before scaling to zero. `@Min(1)`. When set, `minReplicas` must be 0; when not set, `minReplicas` must be > 0. |
 | `strategy` | ScalingStrategyDto | Conditional | Scaling strategy. Nullable. Required when `minReplicas != maxReplicas` (unless `minReplicas=0, maxReplicas=1`). Must be null when `minReplicas == maxReplicas` or when `minReplicas=0, maxReplicas=1`. |
 
 **`ScalingStrategyDto` structure:**
@@ -382,7 +382,7 @@ The `source` JSON column lives on the base `DeploymentEntity`, storing a `Persis
 - Scaling DTO: `com.epam.aidial.deployment.manager.web.dto.ScalingDto` (minReplicas, maxReplicas, scaleToZeroDelaySeconds, strategy)
 - Scaling strategy DTO: `com.epam.aidial.deployment.manager.web.dto.ScalingStrategyDto` ($type as `ScalingStrategyTypeDto`, threshold)
 - Scaling strategy type enum: `com.epam.aidial.deployment.manager.web.dto.ScalingStrategyTypeDto` (PENDING_REQUESTS, ACTIVE_REQUESTS, HARDWARE_USAGE)
-- Scaling validator: `com.epam.aidial.deployment.manager.web.validation.ScalingValidator` (validates strategy presence rules based on replica counts)
+- Scaling validator: `com.epam.aidial.deployment.manager.web.validation.ScalingValidator` (validates strategy presence rules based on replica counts; validates minReplicas/scaleToZeroDelaySeconds cross-field constraints)
 - Scaling DTO mapper: `com.epam.aidial.deployment.manager.web.mapper.ScalingDtoMapper`
 - Domain scaling model: `com.epam.aidial.deployment.manager.model.Scaling`, `com.epam.aidial.deployment.manager.model.ScalingStrategy`, `com.epam.aidial.deployment.manager.model.ScalingStrategyType`
 - Probe properties DTO: `com.epam.aidial.deployment.manager.web.dto.probe.ProbePropertiesDto`

--- a/src/main/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidator.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidator.java
@@ -40,6 +40,13 @@ public class ScalingValidator implements ConstraintValidator<ValidScaling, Scali
             return false;
         }
 
+        if (value.getScaleToZeroDelaySeconds() != null && minReplicas != 0) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("minReplicas must be 0 when scaleToZeroDelaySeconds is set")
+                    .addConstraintViolation();
+            return false;
+        }
+
         if (minReplicas != maxReplicas && !(minReplicas == 0 && maxReplicas == 1) && value.getStrategy() == null) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("strategy must not be null when minReplicas does not equal maxReplicas")

--- a/src/main/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidator.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidator.java
@@ -47,6 +47,13 @@ public class ScalingValidator implements ConstraintValidator<ValidScaling, Scali
             return false;
         }
 
+        if (value.getScaleToZeroDelaySeconds() == null && minReplicas == 0) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("minReplicas must be bigger than 0 when scaleToZeroDelaySeconds is not set")
+                    .addConstraintViolation();
+            return false;
+        }
+
         if (minReplicas != maxReplicas && !(minReplicas == 0 && maxReplicas == 1) && value.getStrategy() == null) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("strategy must not be null when minReplicas does not equal maxReplicas")

--- a/src/test/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidatorTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidatorTest.java
@@ -95,6 +95,30 @@ class ScalingValidatorTest {
     }
 
     @Test
+    void shouldFailWhenScaleToZeroDelayNullAndMinReplicasZero() {
+        ScalingDto dto = new ScalingDto();
+        dto.setMinReplicas(0);
+        dto.setMaxReplicas(2);
+        dto.setScaleToZeroDelaySeconds(null);
+
+        assertThat(validator.isValid(dto, context)).isFalse();
+        verify(context).buildConstraintViolationWithTemplate(
+                "minReplicas must be bigger than 0 when scaleToZeroDelaySeconds is not set");
+    }
+
+    @Test
+    void shouldBeValidWhenScaleToZeroDelayNullAndMinReplicasPositive() {
+        ScalingDto dto = new ScalingDto();
+        dto.setMinReplicas(1);
+        dto.setMaxReplicas(2);
+        dto.setScaleToZeroDelaySeconds(null);
+        dto.setStrategy(new ScalingStrategyDto(ScalingStrategyTypeDto.ACTIVE_REQUESTS, 50));
+
+        assertThat(validator.isValid(dto, context)).isTrue();
+        verifyNoInteractions(context);
+    }
+
+    @Test
     void shouldFailWhenMinGreaterThanMax() {
         ScalingDto dto = new ScalingDto();
         dto.setMinReplicas(3);

--- a/src/test/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidatorTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/web/validation/ScalingValidatorTest.java
@@ -70,6 +70,31 @@ class ScalingValidatorTest {
     }
 
     @Test
+    void shouldBeValidWhenScaleToZeroDelaySetAndMinReplicasZero() {
+        ScalingDto dto = new ScalingDto();
+        dto.setMinReplicas(0);
+        dto.setMaxReplicas(2);
+        dto.setScaleToZeroDelaySeconds(300);
+        dto.setStrategy(new ScalingStrategyDto(ScalingStrategyTypeDto.ACTIVE_REQUESTS, 50));
+
+        assertThat(validator.isValid(dto, context)).isTrue();
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void shouldFailWhenScaleToZeroDelaySetAndMinReplicasNotZero() {
+        ScalingDto dto = new ScalingDto();
+        dto.setMinReplicas(1);
+        dto.setMaxReplicas(3);
+        dto.setScaleToZeroDelaySeconds(300);
+        dto.setStrategy(new ScalingStrategyDto(ScalingStrategyTypeDto.ACTIVE_REQUESTS, 50));
+
+        assertThat(validator.isValid(dto, context)).isFalse();
+        verify(context).buildConstraintViolationWithTemplate(
+                "minReplicas must be 0 when scaleToZeroDelaySeconds is set");
+    }
+
+    @Test
     void shouldFailWhenMinGreaterThanMax() {
         ScalingDto dto = new ScalingDto();
         dto.setMinReplicas(3);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

- #269
- #264  

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Added new validations for deployment scaling configuration: 

- if scaleToZeroDelaySeconds is not null and minReplicas != 0, the validation fails with message "minReplicas must be 0 when scaleToZeroDelaySeconds is set".
- if scaleToZeroDelaySeconds is null and minReplicas == 0, the validation fails with message "minReplicas must be bigger than 0 when scaleToZeroDelaySeconds is not set".

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.