### PR TITLE
fix: add grace period for not ready KNative deployments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,7 @@ Set `app.build.mcp-proxy.images.alpine` and `app.build.mcp-proxy.images.debian` 
 | `app.knative.deploy.startup-timeout`          | `K8S_KNATIVE_DEPLOYMENT_STARTUP_TIMEOUT_SEC`          | `300`         | No                                                | -            | Knative service startup timeout in seconds                             |
 | `app.knative.deploy.undeploy-timeout`         | `K8S_KNATIVE_DEPLOYMENT_UNDEPLOY_TIMEOUT_SEC`         | `300`         | No                                                | -            | Knative service undeploy timeout in seconds                            |
 | `app.knative.deploy.informer-resync-interval` | `K8S_KNATIVE_DEPLOYMENT_INFORMER_RESYNC_INTERVAL_SEC` | `60`          | No                                                | -            | Kubernetes informer resync interval in seconds for Knative deployments |
+| `app.knative.deploy.ready-grace-period`       | `K8S_KNATIVE_DEPLOYMENT_READY_GRACE_PERIOD_SEC`       | `15`          | No                                                | -            | Grace period in seconds after Ready=False before reporting CRASHED status. Set to 0 to disable |
 
 
 #### NIM (NVIDIA Inference Microservices) Configuration

--- a/specs/deployments/spec.md
+++ b/specs/deployments/spec.md
@@ -38,6 +38,14 @@ Note: calling `deploy` on an already-active deployment (PENDING, RUNNING, CRASHE
 | `STOPPING` | Undeploy requested; Kubernetes resources are being removed |
 | `STOPPED` | Undeployed; configuration retained but no Kubernetes resources |
 
+### Knative ready grace period
+
+For Knative-based deployments (MCP, Interceptor, Adapter, Application), a configurable **ready grace period** (`K8S_KNATIVE_DEPLOYMENT_READY_GRACE_PERIOD_SEC`, default: 15s) prevents false `CRASHED` status during transient readiness probe failures. On some cloud providers (e.g., GKE), networking setup can take several seconds during which the Knative `Ready` condition is temporarily `False` before flipping to `True`.
+
+During the grace period after the `Ready` condition transitions to `False`, the system reports `PENDING` instead of `CRASHED`. Once the grace period expires and the condition is still `False`, the status transitions to `CRASHED`. Setting the grace period to `0` disables this behavior.
+
+This does not apply to NIM or KServe deployments, which have distinct failure states in their respective operators and only map definitive failures to `CRASHED`.
+
 ## Requirements
 
 ### Requirement: List deployments

--- a/src/main/java/com/epam/aidial/deployment/manager/configuration/KnativeDeployProperties.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/configuration/KnativeDeployProperties.java
@@ -12,5 +12,6 @@ public class KnativeDeployProperties {
     private int startupTimeout;
     private int undeployTimeout;
     private long informerResyncInterval;
+    private int readyGracePeriod;
 }
 

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManager.java
@@ -24,6 +24,7 @@ import com.epam.aidial.deployment.manager.service.deployment.healthcheck.HealthC
 import com.epam.aidial.deployment.manager.service.manifest.KnativeManifestGenerator;
 import com.epam.aidial.deployment.manager.service.manifest.ManifestGenerator;
 import com.epam.aidial.deployment.manager.service.pipeline.specification.CiliumNetworkPolicyCreator;
+import com.epam.aidial.deployment.manager.utils.K8sParseUtils;
 import io.fabric8.knative.pkg.apis.Condition;
 import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -35,6 +36,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -53,6 +55,7 @@ public class KnativeDeploymentManager extends AbstractDeploymentManager<Deployme
     private final HealthCheckProvider healthCheckProvider;
 
     private final String serviceContainer;
+    private final int readyGracePeriodSec;
 
     public KnativeDeploymentManager(
             K8sClient k8sClient,
@@ -76,6 +79,7 @@ public class KnativeDeploymentManager extends AbstractDeploymentManager<Deployme
         this.healthCheckProvider = healthCheckProvider;
         this.k8sKnativeClient = k8sKnativeClient;
         this.serviceContainer = serviceContainer;
+        this.readyGracePeriodSec = knativeDeployProperties.getReadyGracePeriod();
     }
 
     @Override
@@ -217,6 +221,11 @@ public class KnativeDeploymentManager extends AbstractDeploymentManager<Deployme
         if (KubernetesConditionConstants.STATUS_TRUE.equals(readyCondition.getStatus())) {
             return DeploymentStatus.RUNNING;
         } else if (KubernetesConditionConstants.STATUS_FALSE.equals(readyCondition.getStatus())) {
+            if (isWithinReadyGracePeriod(readyCondition)) {
+                log.debug("Ready=False within grace period (lastTransitionTime: {}). Treating as PENDING",
+                        readyCondition.getLastTransitionTime());
+                return DeploymentStatus.PENDING;
+            }
             return DeploymentStatus.CRASHED;
         } else {
             return DeploymentStatus.PENDING;
@@ -262,6 +271,18 @@ public class KnativeDeploymentManager extends AbstractDeploymentManager<Deployme
 
         var readyCondition = readyConditionOptional.get();
         return KubernetesConditionConstants.STATUS_TRUE.equals(readyCondition.getStatus());
+    }
+
+    private boolean isWithinReadyGracePeriod(Condition readyCondition) {
+        if (readyGracePeriodSec <= 0) {
+            return false;
+        }
+        var transitionTime = K8sParseUtils.parseInstant(readyCondition.getLastTransitionTime());
+        if (transitionTime == null) {
+            return false;
+        }
+        var elapsed = Duration.between(transitionTime, Instant.now());
+        return elapsed.getSeconds() < readyGracePeriodSec;
     }
 
     private Condition findReadyCondition(List<Condition> conditions) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,7 @@ app:
       startup-timeout: ${K8S_KNATIVE_DEPLOYMENT_STARTUP_TIMEOUT_SEC:60}
       undeploy-timeout: ${K8S_KNATIVE_DEPLOYMENT_UNDEPLOY_TIMEOUT_SEC:300}
       informer-resync-interval: ${K8S_KNATIVE_DEPLOYMENT_INFORMER_RESYNC_INTERVAL_SEC:600}
+      ready-grace-period: ${K8S_KNATIVE_DEPLOYMENT_READY_GRACE_PERIOD_SEC:15}
   nim:
     enabled: ${K8S_NIM_ENABLED:false}
     deploy:

--- a/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/service/deployment/KnativeDeploymentManagerTest.java
@@ -29,7 +29,9 @@ import com.epam.aidial.deployment.manager.service.manifest.ManifestGenerator;
 import com.epam.aidial.deployment.manager.service.pipeline.specification.CiliumNetworkPolicyCreator;
 import com.epam.aidial.deployment.manager.utils.K8sNamingUtils;
 import io.cilium.v2.CiliumNetworkPolicy;
+import io.fabric8.knative.pkg.apis.Condition;
 import io.fabric8.knative.serving.v1.Service;
+import io.fabric8.knative.serving.v1.ServiceStatus;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerStateBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -78,6 +80,7 @@ class KnativeDeploymentManagerTest {
     private static final UUID IMAGE_DEFINITION_ID = UUID.randomUUID();
     private static final int STARTUP_TIMEOUT = 60;
     private static final int UNDEPLOY_TIMEOUT = 300;
+    private static final int READY_GRACE_PERIOD = 15;
 
     private static final String SERVICE_URL = "https://service-url.example.com";
     private static final String SERVICE_NAME = "test-" + DEPLOYMENT_ID;
@@ -132,6 +135,7 @@ class KnativeDeploymentManagerTest {
         knativeDeployProperties.setNamespace(NAMESPACE);
         knativeDeployProperties.setStartupTimeout(STARTUP_TIMEOUT);
         knativeDeployProperties.setUndeployTimeout(UNDEPLOY_TIMEOUT);
+        knativeDeployProperties.setReadyGracePeriod(READY_GRACE_PERIOD);
 
         knativeDeploymentManager = new KnativeDeploymentManager(
                 k8sClient,
@@ -688,6 +692,141 @@ class KnativeDeploymentManagerTest {
         // Then
         assertThat(result).isTrue();
         verify(deploymentRepository).updateStatus(eq(DEPLOYMENT_ID), eq(DeploymentStatus.STOPPING));
+    }
+
+    @Test
+    void reconcile_shouldTreatReadyFalseAsPendingWithinGracePeriod() {
+        // Given
+        Deployment deployment = createDeployment(DeploymentStatus.PENDING);
+        Service service = createKnativeServiceWithReadyCondition("False", Instant.now().minusSeconds(5).toString());
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+
+        var reconcileConfig = ReconcileConfig.<Service>builder()
+                .deploymentId(DEPLOYMENT_ID)
+                .service(service)
+                .serviceIsMissing(false)
+                .initiator("Reconciliation Test")
+                .ignorePendingOnServiceNotFound(false)
+                .build();
+
+        // When
+        boolean result = knativeDeploymentManager.reconcile(reconcileConfig);
+
+        // Then - status is already PENDING, so no update needed
+        assertThat(result).isFalse();
+        verify(deploymentRepository, never()).updateStatus(any(), any());
+    }
+
+    @Test
+    void reconcile_shouldTreatReadyFalseAsCrashedAfterGracePeriod() {
+        // Given
+        Deployment deployment = createDeployment(DeploymentStatus.PENDING);
+        Service service = createKnativeServiceWithReadyCondition("False", Instant.now().minusSeconds(60).toString());
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+
+        var reconcileConfig = ReconcileConfig.<Service>builder()
+                .deploymentId(DEPLOYMENT_ID)
+                .service(service)
+                .serviceIsMissing(false)
+                .initiator("Reconciliation Test")
+                .ignorePendingOnServiceNotFound(false)
+                .build();
+
+        // When
+        boolean result = knativeDeploymentManager.reconcile(reconcileConfig);
+
+        // Then
+        assertThat(result).isTrue();
+        verify(deploymentRepository).updateStatus(eq(DEPLOYMENT_ID), eq(DeploymentStatus.CRASHED));
+    }
+
+    @Test
+    void reconcile_shouldTreatReadyFalseAsCrashedWhenLastTransitionTimeIsNull() {
+        // Given
+        Deployment deployment = createDeployment(DeploymentStatus.PENDING);
+        Service service = createKnativeServiceWithReadyCondition("False", null);
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+
+        var reconcileConfig = ReconcileConfig.<Service>builder()
+                .deploymentId(DEPLOYMENT_ID)
+                .service(service)
+                .serviceIsMissing(false)
+                .initiator("Reconciliation Test")
+                .ignorePendingOnServiceNotFound(false)
+                .build();
+
+        // When
+        boolean result = knativeDeploymentManager.reconcile(reconcileConfig);
+
+        // Then
+        assertThat(result).isTrue();
+        verify(deploymentRepository).updateStatus(eq(DEPLOYMENT_ID), eq(DeploymentStatus.CRASHED));
+    }
+
+    @Test
+    void reconcile_shouldTreatReadyFalseAsCrashedWhenGracePeriodDisabled() {
+        // Given - recreate manager with grace period = 0
+        var knativeDeployProperties = new KnativeDeployProperties();
+        knativeDeployProperties.setNamespace(NAMESPACE);
+        knativeDeployProperties.setStartupTimeout(STARTUP_TIMEOUT);
+        knativeDeployProperties.setUndeployTimeout(UNDEPLOY_TIMEOUT);
+        knativeDeployProperties.setReadyGracePeriod(0);
+
+        var managerWithDisabledGrace = new KnativeDeploymentManager(
+                k8sClient,
+                manifestGenerator,
+                knativeManifestGenerator,
+                deploymentRepository,
+                imageDefinitionService,
+                containerPortResolver,
+                disposableResourceManager,
+                ciliumNetworkPolicyCreator,
+                healthCheckProvider,
+                k8sKnativeClient,
+                knativeDeployProperties,
+                SERVICE_CONTAINER
+        );
+
+        Deployment deployment = createDeployment(DeploymentStatus.PENDING);
+        Service service = createKnativeServiceWithReadyCondition("False", Instant.now().minusSeconds(5).toString());
+
+        when(deploymentRepository.getById(DEPLOYMENT_ID)).thenReturn(Optional.of(deployment));
+
+        var reconcileConfig = ReconcileConfig.<Service>builder()
+                .deploymentId(DEPLOYMENT_ID)
+                .service(service)
+                .serviceIsMissing(false)
+                .initiator("Reconciliation Test")
+                .ignorePendingOnServiceNotFound(false)
+                .build();
+
+        // When
+        boolean result = managerWithDisabledGrace.reconcile(reconcileConfig);
+
+        // Then - even though lastTransitionTime is recent, grace period is disabled → CRASHED
+        assertThat(result).isTrue();
+        verify(deploymentRepository).updateStatus(eq(DEPLOYMENT_ID), eq(DeploymentStatus.CRASHED));
+    }
+
+    private Service createKnativeServiceWithReadyCondition(String status, String lastTransitionTime) {
+        var service = mock(Service.class);
+        var metadata = new ObjectMeta();
+        metadata.setName(SERVICE_NAME);
+        when(service.getMetadata()).thenReturn(metadata);
+
+        var condition = new Condition();
+        condition.setType("Ready");
+        condition.setStatus(status);
+        condition.setLastTransitionTime(lastTransitionTime);
+
+        var serviceStatus = mock(ServiceStatus.class);
+        when(serviceStatus.getConditions()).thenReturn(List.of(condition));
+        when(service.getStatus()).thenReturn(serviceStatus);
+
+        return service;
     }
 
     private Deployment createDeployment(DeploymentStatus status) {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #253 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Added a configurable ready grace period (default 15s, K8S_KNATIVE_DEPLOYMENT_READY_GRACE_PERIOD_SEC) for Knative deployments that reports PENDING instead of CRASHED when the Ready condition has been False for less than the grace period, preventing false crash status during transient readiness probe failures.                                                                                                                                                         
- NIM and KServe deployments are unaffected — they already only map definitive failure states to CRASHED. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.