### PR TITLE
fix: pin libcrypto3 and libssl3 to 3.5.6-r0 (CVE-2026-28390)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --chown=appuser:appuser docker-entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-RUN apk add --no-cache zlib=1.3.2-r0 
+RUN apk add --no-cache zlib=1.3.2-r0 libcrypto3=3.5.6-r0 libssl3=3.5.6-r0
 
 USER appuser
 


### PR DESCRIPTION
### Applicable issues

N/A — security fix for Trivy-detected vulnerability.

### Description of changes

Pin `libcrypto3` and `libssl3` to `3.5.6-r0` in the runtime Docker image to resolve CVE-2026-28390 (HIGH — OpenSSL DoS via NULL pointer dereference in CMS).

Trivy scan flagged `libcrypto3` 3.5.5-r0 and `libssl3` 3.5.5-r0 in the `amazoncorretto:21-alpine` base image. The fix is available in 3.5.6-r0.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.