### PR TITLE
feat:  allow meta fields updates of built image definition

### DIFF
--- a/specs/image-definitions/spec.md
+++ b/specs/image-definitions/spec.md
@@ -80,13 +80,37 @@ Status: **Implemented**
 - **THEN** the system responds with 400
 
 ### Requirement: Update image definition
-The system SHALL update an existing image definition by ID.
+The system SHALL update an existing image definition by ID. The set of fields that may be mutated depends on the current `buildStatus`:
+
+- **NOT_BUILT, BUILD_FAILED, BUILD_STOPPED** — full replacement is allowed. Any update resets `buildStatus` to `NOT_BUILT` because the prior build artifact (if any) is no longer valid against the new configuration.
+- **BUILD_SUCCESSFUL** — only **meta fields** may change: `description`, `author`, `topics`, `license`. The update is applied in place; `buildStatus`, `imageName`, `builtAt`, and build logs are preserved, and the built image remains valid. Any change to a build-affecting field (`name`, `version`, `source`, `allowedDomains`, `imageBuilder`, or a subtype-specific field such as MCP `transportType`) is rejected with HTTP 400.
+- **BUILDING** — the image definition is read-only. Any update is rejected with HTTP 400.
+
+`allowedDomains` is compared order-insensitively (multiset semantics) during build-affecting detection — a cosmetic reorder of the same domains is treated as no change, mirroring `DeploymentService.isApplicableForCiliumNetworkPolicyUpdate`.
+
+The configuration import path (`POST /api/v1/configs/import`, see `export-import` spec) bypasses the `BUILD_SUCCESSFUL` restriction and uses full-replacement semantics regardless of the prior build status.
 
 Status: **Implemented**
 
-#### Scenario: Successful update
-- **WHEN** `PUT /api/v1/images/definitions/{id}` is called with a valid body
-- **THEN** the image definition is updated and returned with a new `updatedAt` timestamp
+#### Scenario: Full update when not BUILD_SUCCESSFUL or BUILDING
+- **WHEN** `PUT /api/v1/images/definitions/{id}` is called with a valid body and current `buildStatus` is `NOT_BUILT`, `BUILD_FAILED`, or `BUILD_STOPPED`
+- **THEN** the image definition is fully replaced, `buildStatus` is reset to `NOT_BUILT`, and a new `updatedAt` timestamp is set
+
+#### Scenario: Meta-only update when BUILD_SUCCESSFUL
+- **WHEN** `PUT /api/v1/images/definitions/{id}` is called while current `buildStatus` is `BUILD_SUCCESSFUL` and only meta fields (`description`, `author`, `topics`, `license`) differ from the stored record
+- **THEN** the meta fields are updated; `buildStatus`, `imageName`, `builtAt`, and build logs are preserved
+
+#### Scenario: allowedDomains reorder is not a build-affecting change
+- **WHEN** `PUT /api/v1/images/definitions/{id}` is called while current `buildStatus` is `BUILD_SUCCESSFUL` and `allowedDomains` contains the same entries as the stored record in a different order (meta fields may also change)
+- **THEN** the update is treated as meta-only and applied in place; `buildStatus` is preserved
+
+#### Scenario: Build-affecting update when BUILD_SUCCESSFUL is rejected
+- **WHEN** `PUT /api/v1/images/definitions/{id}` is called while current `buildStatus` is `BUILD_SUCCESSFUL` and any build-affecting field (`name`, `version`, `source`, `allowedDomains` membership, `imageBuilder`, or a subtype-specific field) differs
+- **THEN** the system responds with 400 and the stored record is unchanged
+
+#### Scenario: Update rejected while BUILDING
+- **WHEN** `PUT /api/v1/images/definitions/{id}` is called while current `buildStatus` is `BUILDING`
+- **THEN** the system responds with 400
 
 #### Scenario: Non-existent ID
 - **WHEN** `PUT /api/v1/images/definitions/{id}` is called with an unknown ID

--- a/src/main/java/com/epam/aidial/deployment/manager/dao/mapper/PersistenceImageDefinitionMapper.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/mapper/PersistenceImageDefinitionMapper.java
@@ -45,18 +45,7 @@ public interface PersistenceImageDefinitionMapper {
 
     default void updateEntityFromDomain(ImageDefinition domain, ImageDefinitionEntity existingEntity) {
         var updatedEntity = toImageDefinitionEntity(domain);
-
-        if (!existingEntity.getClass().equals(updatedEntity.getClass())) {
-            throw new IllegalArgumentException("""
-                    Updated entity and existing entity types must match.
-                    ImageId: %s. Existing type: %s. Updated type: %s
-                    """.formatted(
-                    domain.getId(),
-                    existingEntity.getClass().getSimpleName(),
-                    updatedEntity.getClass().getSimpleName()
-            )
-            );
-        }
+        assertSameType(domain, existingEntity, updatedEntity);
 
         // do not update id, createdAt, updatedAt, buildStatus, imageName, builtAt, type
         existingEntity.setName(updatedEntity.getName());
@@ -78,10 +67,20 @@ public interface PersistenceImageDefinitionMapper {
         }
     }
 
-    // TODO: unify lines 47-59 with 83-95
     default void updateMetaFieldsFromDomain(ImageDefinition domain, ImageDefinitionEntity existingEntity) {
         var updatedEntity = toImageDefinitionEntity(domain);
+        assertSameType(domain, existingEntity, updatedEntity);
 
+        // Only meta fields — preserves buildStatus, imageName, builtAt and build-affecting fields.
+        existingEntity.setDescription(updatedEntity.getDescription());
+        existingEntity.setAuthor(updatedEntity.getAuthor());
+        existingEntity.setTopics(updatedEntity.getTopics());
+        existingEntity.setLicense(updatedEntity.getLicense());
+    }
+
+    private static void assertSameType(ImageDefinition domain,
+                                       ImageDefinitionEntity existingEntity,
+                                       ImageDefinitionEntity updatedEntity) {
         if (!existingEntity.getClass().equals(updatedEntity.getClass())) {
             throw new IllegalArgumentException("""
                     Updated entity and existing entity types must match.
@@ -93,12 +92,6 @@ public interface PersistenceImageDefinitionMapper {
             )
             );
         }
-
-        // Only meta fields — preserves buildStatus, imageName, builtAt and build-affecting fields.
-        existingEntity.setDescription(updatedEntity.getDescription());
-        existingEntity.setAuthor(updatedEntity.getAuthor());
-        existingEntity.setTopics(updatedEntity.getTopics());
-        existingEntity.setLicense(updatedEntity.getLicense());
     }
 
     @Named("getTypeFromClass")

--- a/src/main/java/com/epam/aidial/deployment/manager/dao/mapper/PersistenceImageDefinitionMapper.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/mapper/PersistenceImageDefinitionMapper.java
@@ -78,6 +78,29 @@ public interface PersistenceImageDefinitionMapper {
         }
     }
 
+    // TODO: unify lines 47-59 with 83-95
+    default void updateMetaFieldsFromDomain(ImageDefinition domain, ImageDefinitionEntity existingEntity) {
+        var updatedEntity = toImageDefinitionEntity(domain);
+
+        if (!existingEntity.getClass().equals(updatedEntity.getClass())) {
+            throw new IllegalArgumentException("""
+                    Updated entity and existing entity types must match.
+                    ImageId: %s. Existing type: %s. Updated type: %s
+                    """.formatted(
+                    domain.getId(),
+                    existingEntity.getClass().getSimpleName(),
+                    updatedEntity.getClass().getSimpleName()
+            )
+            );
+        }
+
+        // Only meta fields — preserves buildStatus, imageName, builtAt and build-affecting fields.
+        existingEntity.setDescription(updatedEntity.getDescription());
+        existingEntity.setAuthor(updatedEntity.getAuthor());
+        existingEntity.setTopics(updatedEntity.getTopics());
+        existingEntity.setLicense(updatedEntity.getLicense());
+    }
+
     @Named("getTypeFromClass")
     default String getTypeFromClass(ImageDefinition domain) {
         Class<?> entityClass = domain.getClass();

--- a/src/main/java/com/epam/aidial/deployment/manager/dao/repository/ImageDefinitionRepository.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/repository/ImageDefinitionRepository.java
@@ -109,6 +109,16 @@ public class ImageDefinitionRepository {
         return mapper.toImageDefinition(savedEntity);
     }
 
+    public ImageDefinition updateImageDefinitionMetaFields(UUID id, ImageDefinition updatedImageDefinition) {
+        var existingEntity = findImageDefinitionById(id);
+
+        mapper.updateMetaFieldsFromDomain(updatedImageDefinition, existingEntity);
+
+        var savedEntity = imageDefinitionJpaRepository.saveAndFlush(existingEntity);
+        log.debug("Image definition '{}' meta fields updated successfully", id);
+        return mapper.toImageDefinition(savedEntity);
+    }
+
     public void addBuildLogs(UUID id, List<String> logs) {
         if (!imageDefinitionJpaRepository.existsById(id)) {
             throw new EntityNotFoundException("Image definition not found by id: %s".formatted(id));

--- a/src/main/java/com/epam/aidial/deployment/manager/model/ImageDefinition.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/model/ImageDefinition.java
@@ -7,9 +7,12 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Data
@@ -45,4 +48,26 @@ public abstract class ImageDefinition {
 
     private List<String> allowedDomains;
     private ImageBuilder imageBuilder;
+
+    /**
+     * Returns true when {@code other} has the same values for every field that contributes to the
+     * built image. Meta fields (description, author, topics, license) and system-managed fields
+     * (id, timestamps, build outputs) are intentionally excluded. Subtypes that add build-affecting
+     * fields MUST override and compose via {@code super.hasSameBuildAffectingFields(other)}.
+     */
+    public boolean hasSameBuildAffectingFields(ImageDefinition other) {
+        return other != null
+                && getClass() == other.getClass()
+                && Objects.equals(name, other.name)
+                && Objects.equals(version, other.version)
+                && Objects.equals(source, other.source)
+                && sameAllowedDomains(allowedDomains, other.allowedDomains)
+                && Objects.equals(imageBuilder, other.imageBuilder);
+    }
+
+    private static boolean sameAllowedDomains(Collection<String> a, Collection<String> b) {
+        return CollectionUtils.isEqualCollection(
+                a == null ? List.of() : a,
+                b == null ? List.of() : b);
+    }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/model/McpImageDefinition.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/model/McpImageDefinition.java
@@ -8,6 +8,8 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
+import java.util.Objects;
+
 @Getter
 @Setter
 @SuperBuilder
@@ -17,4 +19,11 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class McpImageDefinition extends ImageDefinition {
     private McpTransportType transportType;
+
+    @Override
+    public boolean hasSameBuildAffectingFields(ImageDefinition other) {
+        // super ensures same class — cast below is safe.
+        return super.hasSameBuildAffectingFields(other)
+                && Objects.equals(transportType, ((McpImageDefinition) other).transportType);
+    }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/service/ImageDefinitionService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/ImageDefinitionService.java
@@ -13,6 +13,7 @@ import com.epam.aidial.deployment.manager.model.ImageDefinition;
 import com.epam.aidial.deployment.manager.model.ImageDefinitionView;
 import com.epam.aidial.deployment.manager.model.ImageStatus;
 import com.epam.aidial.deployment.manager.model.ImageType;
+import com.epam.aidial.deployment.manager.model.McpImageDefinition;
 import com.epam.aidial.deployment.manager.service.audit.HistoryService;
 import com.epam.aidial.deployment.manager.service.security.SecurityClaimsExtractor;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -124,13 +126,36 @@ public class ImageDefinitionService {
         var existing = imageDefinitionRepository.getImageDefinitionById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Image definition not found by id: %s".formatted(id)));
 
-        // Allowing update of built images on import
-        if ((!fromImport && existing.getBuildStatus() == ImageStatus.BUILD_SUCCESSFUL) || existing.getBuildStatus() == ImageStatus.BUILDING) {
-            throw new IllegalArgumentException("Cannot update image definition with status %s. It is read-only."
-                    .formatted(existing.getBuildStatus()));
+        if (existing.getBuildStatus() == ImageStatus.BUILDING) {
+            throw new IllegalArgumentException("Cannot update image definition with status BUILDING. It is read-only.");
+        }
+
+        if (!fromImport && existing.getBuildStatus() == ImageStatus.BUILD_SUCCESSFUL) {
+            if (!areOnlyMetaFieldsChanged(existing, updatedImageDefinition)) {
+                throw new IllegalArgumentException(
+                        "Cannot update build-affecting fields of a built image definition. "
+                                + "Only description, author, topics, and license can be updated while build status is BUILD_SUCCESSFUL.");
+            }
+            return imageDefinitionRepository.updateImageDefinitionMetaFields(id, updatedImageDefinition);
         }
 
         return imageDefinitionRepository.updateImageDefinition(id, updatedImageDefinition);
+    }
+
+    // TODO: refactor 'areOnlyMetaFieldsChanged' method to be more maintainable
+    private static boolean areOnlyMetaFieldsChanged(ImageDefinition existing, ImageDefinition updated) {
+        if (!Objects.equals(existing.getName(), updated.getName())
+                || !Objects.equals(existing.getVersion(), updated.getVersion())
+                || !Objects.equals(existing.getSource(), updated.getSource())
+                || !Objects.equals(existing.getAllowedDomains(), updated.getAllowedDomains())
+                || !Objects.equals(existing.getImageBuilder(), updated.getImageBuilder())) {
+            return false;
+        }
+        if (existing instanceof McpImageDefinition existingMcp && updated instanceof McpImageDefinition updatedMcp
+                && !Objects.equals(existingMcp.getTransportType(), updatedMcp.getTransportType())) {
+            return false;
+        }
+        return true;
     }
 
     @Transactional

--- a/src/main/java/com/epam/aidial/deployment/manager/service/ImageDefinitionService.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/ImageDefinitionService.java
@@ -13,7 +13,6 @@ import com.epam.aidial.deployment.manager.model.ImageDefinition;
 import com.epam.aidial.deployment.manager.model.ImageDefinitionView;
 import com.epam.aidial.deployment.manager.model.ImageStatus;
 import com.epam.aidial.deployment.manager.model.ImageType;
-import com.epam.aidial.deployment.manager.model.McpImageDefinition;
 import com.epam.aidial.deployment.manager.service.audit.HistoryService;
 import com.epam.aidial.deployment.manager.service.security.SecurityClaimsExtractor;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -131,7 +129,7 @@ public class ImageDefinitionService {
         }
 
         if (!fromImport && existing.getBuildStatus() == ImageStatus.BUILD_SUCCESSFUL) {
-            if (!areOnlyMetaFieldsChanged(existing, updatedImageDefinition)) {
+            if (!existing.hasSameBuildAffectingFields(updatedImageDefinition)) {
                 throw new IllegalArgumentException(
                         "Cannot update build-affecting fields of a built image definition. "
                                 + "Only description, author, topics, and license can be updated while build status is BUILD_SUCCESSFUL.");
@@ -140,22 +138,6 @@ public class ImageDefinitionService {
         }
 
         return imageDefinitionRepository.updateImageDefinition(id, updatedImageDefinition);
-    }
-
-    // TODO: refactor 'areOnlyMetaFieldsChanged' method to be more maintainable
-    private static boolean areOnlyMetaFieldsChanged(ImageDefinition existing, ImageDefinition updated) {
-        if (!Objects.equals(existing.getName(), updated.getName())
-                || !Objects.equals(existing.getVersion(), updated.getVersion())
-                || !Objects.equals(existing.getSource(), updated.getSource())
-                || !Objects.equals(existing.getAllowedDomains(), updated.getAllowedDomains())
-                || !Objects.equals(existing.getImageBuilder(), updated.getImageBuilder())) {
-            return false;
-        }
-        if (existing instanceof McpImageDefinition existingMcp && updated instanceof McpImageDefinition updatedMcp
-                && !Objects.equals(existingMcp.getTransportType(), updatedMcp.getTransportType())) {
-            return false;
-        }
-        return true;
     }
 
     @Transactional

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/ImageDefinitionBuildFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/ImageDefinitionBuildFunctionalTest.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.deployment.manager.functional.tests;
 
 import com.epam.aidial.deployment.manager.functional.utils.FunctionalTestHelper;
+import com.epam.aidial.deployment.manager.model.DockerImageSource;
 import com.epam.aidial.deployment.manager.model.ImageDefinition;
 import com.epam.aidial.deployment.manager.model.ImageStatus;
 import com.epam.aidial.deployment.manager.service.ImageBuildRunner;
@@ -16,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.AopTestUtils;
 
 import java.time.Instant;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -127,7 +129,7 @@ public abstract class ImageDefinitionBuildFunctionalTest {
     }
 
     @Test
-    public void shouldPreventUpdateWhenBuildStatusIsSuccessful() {
+    public void shouldRejectBuildAffectingUpdateWhenBuildSuccessful() {
         // Given
         var imageDef = imageDefinitionService.createImageDefinition(FunctionalTestHelper.createMcpImageDefinition());
         var imageDefinitionId = imageDef.getId();
@@ -135,7 +137,7 @@ public abstract class ImageDefinitionBuildFunctionalTest {
         // Set build status to successful
         imageDefinitionService.completeBuildSuccessfully(imageDefinitionId, "test-image:1.0.0", System.currentTimeMillis());
 
-        // When - Try to update
+        // When - Try to update a build-affecting field (name)
         var updatedImageDef = imageDefinitionService.getImageDefinition(imageDefinitionId)
                 .orElseThrow();
         updatedImageDef.setName("updated-name");
@@ -143,7 +145,55 @@ public abstract class ImageDefinitionBuildFunctionalTest {
         // Then - Should throw exception
         assertThatThrownBy(() -> imageDefinitionService.updateImageDefinition(imageDefinitionId, updatedImageDef))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Cannot update image definition with status BUILD_SUCCESSFUL");
+                .hasMessageContaining("Cannot update build-affecting fields of a built image definition");
+    }
+
+    @Test
+    public void shouldAllowMetaOnlyUpdateWhenBuildSuccessful() {
+        // Given
+        var imageDef = imageDefinitionService.createImageDefinition(FunctionalTestHelper.createMcpImageDefinition());
+        var imageDefinitionId = imageDef.getId();
+        var testImageName = "test-registry/test-image:1.0.0";
+        var testTimestamp = System.currentTimeMillis();
+        imageDefinitionService.completeBuildSuccessfully(imageDefinitionId, testImageName, testTimestamp);
+
+        // When - Update only meta fields (description, author, topics, license)
+        var updatedImageDef = imageDefinitionService.getImageDefinition(imageDefinitionId)
+                .orElseThrow();
+        updatedImageDef.setDescription("updated-description");
+        updatedImageDef.setAuthor("updated-author");
+        updatedImageDef.setTopics(List.of("new-topic-1", "new-topic-2"));
+        updatedImageDef.setLicense("updated-license");
+
+        var result = imageDefinitionService.updateImageDefinition(imageDefinitionId, updatedImageDef);
+
+        // Then - Meta fields updated; build state preserved
+        assertThat(result.getDescription()).isEqualTo("updated-description");
+        assertThat(result.getAuthor()).isEqualTo("updated-author");
+        assertThat(result.getTopics()).containsExactly("new-topic-1", "new-topic-2");
+        assertThat(result.getLicense()).isEqualTo("updated-license");
+        assertThat(result.getBuildStatus()).isEqualTo(ImageStatus.BUILD_SUCCESSFUL);
+        assertThat(result.getImageName()).isEqualTo(testImageName);
+        assertThat(result.getBuiltAt()).isEqualTo(Instant.ofEpochMilli(testTimestamp));
+    }
+
+    @Test
+    public void shouldRejectSourceChangeWhenBuildSuccessful() {
+        // Given
+        var imageDef = imageDefinitionService.createImageDefinition(FunctionalTestHelper.createMcpImageDefinition());
+        var imageDefinitionId = imageDef.getId();
+        imageDefinitionService.completeBuildSuccessfully(imageDefinitionId, "test-image:1.0.0", System.currentTimeMillis());
+
+        // When - Try to update source (build-affecting) along with a meta field
+        var updatedImageDef = imageDefinitionService.getImageDefinition(imageDefinitionId)
+                .orElseThrow();
+        updatedImageDef.setDescription("updated-description");
+        updatedImageDef.setSource(new DockerImageSource("http://different-uri", List.of("entry1"), null));
+
+        // Then - Should throw exception
+        assertThatThrownBy(() -> imageDefinitionService.updateImageDefinition(imageDefinitionId, updatedImageDef))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot update build-affecting fields of a built image definition");
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/deployment/manager/model/ImageDefinitionTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/model/ImageDefinitionTest.java
@@ -1,0 +1,223 @@
+package com.epam.aidial.deployment.manager.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImageDefinitionTest {
+
+    @Test
+    void hasSameBuildAffectingFields_identicalDefinitions_returnsTrue() {
+        assertThat(mcpImage().hasSameBuildAffectingFields(mcpImage())).isTrue();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_nullOther_returnsFalse() {
+        assertThat(mcpImage().hasSameBuildAffectingFields(null)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_differentSubtype_returnsFalse() {
+        var mcp = mcpImage();
+        var interceptor = InterceptorImageDefinition.builder()
+                .name("image")
+                .version("1.0.0")
+                .source(dockerSource())
+                .allowedDomains(List.of("foo.com"))
+                .imageBuilder(ImageBuilder.BUILDKIT)
+                .build();
+
+        assertThat(mcp.hasSameBuildAffectingFields(interceptor)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_metaFieldsOnlyChanged_returnsTrue() {
+        var before = mcpImage();
+        before.setDescription("old");
+        before.setAuthor("old-author");
+        before.setTopics(List.of("t1"));
+        before.setLicense("MIT");
+
+        var after = mcpImage();
+        after.setDescription("new");
+        after.setAuthor("new-author");
+        after.setTopics(List.of("t2", "t3"));
+        after.setLicense("Apache-2.0");
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isTrue();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_nameChanged_returnsFalse() {
+        var before = mcpImage();
+        var after = mcpImage();
+        after.setName("different");
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_versionChanged_returnsFalse() {
+        var before = mcpImage();
+        var after = mcpImage();
+        after.setVersion("2.0.0");
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_imageBuilderChanged_returnsFalse() {
+        var before = mcpImage();
+        var after = mcpImage();
+        after.setImageBuilder(ImageBuilder.BUILDKIT);
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    // --- source ------------------------------------------------------------
+
+    @Test
+    void hasSameBuildAffectingFields_sourceImageUriChanged_returnsFalse() {
+        var before = mcpImage();
+        var after = mcpImage();
+        after.setSource(new DockerImageSource("http://different-uri", List.of("entry1"), null));
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_sourceEntrypointReordered_returnsFalse() {
+        // Docker ENTRYPOINT order is semantically significant (different command); must not be treated as equal.
+        var before = mcpImage();
+        before.setSource(new DockerImageSource("http://test-uri", List.of("a", "b"), null));
+        var after = mcpImage();
+        after.setSource(new DockerImageSource("http://test-uri", List.of("b", "a"), null));
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_sourceSubtypeChanged_returnsFalse() {
+        // DockerImageSource vs GitDockerfileImageSource — same abstract parent, different concrete type.
+        var before = mcpImage();
+        var after = mcpImage();
+        after.setSource(GitDockerfileImageSource.builder()
+                .url("http://test-uri")
+                .branchName("main")
+                .sha("abc")
+                .baseDirectory("")
+                .entrypoint(List.of("entry1"))
+                .build());
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_sourceNestedRegistryRefChanged_returnsFalse() {
+        // ExternalRegistryRef is a record — value-based equals should propagate through DockerImageSource.
+        var before = mcpImage();
+        before.setSource(new DockerImageSource("http://test-uri", List.of("entry1"), new GitHubRef("org/repo-1")));
+        var after = mcpImage();
+        after.setSource(new DockerImageSource("http://test-uri", List.of("entry1"), new GitHubRef("org/repo-2")));
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_sourceNestedRegistryRefEqual_returnsTrue() {
+        var before = mcpImage();
+        before.setSource(new DockerImageSource("http://test-uri", List.of("entry1"), new GitHubRef("org/repo")));
+        var after = mcpImage();
+        after.setSource(new DockerImageSource("http://test-uri", List.of("entry1"), new GitHubRef("org/repo")));
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isTrue();
+    }
+
+    // --- allowedDomains ---------------------------------------------------
+
+    @Test
+    void hasSameBuildAffectingFields_allowedDomainsReordered_returnsTrue() {
+        // Allow-list is set-like (see domain-whitelist spec); ordering is not build-affecting.
+        var before = mcpImage();
+        before.setAllowedDomains(List.of("foo.com", "bar.com", "baz.com"));
+        var after = mcpImage();
+        after.setAllowedDomains(List.of("baz.com", "foo.com", "bar.com"));
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isTrue();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_allowedDomainsDuplicateCountDiffers_returnsFalse() {
+        // Multiset semantics — matches CollectionUtils.isEqualCollection used by
+        // DeploymentService.isApplicableForCiliumNetworkPolicyUpdate. Order doesn't matter,
+        // but frequency does.
+        var before = mcpImage();
+        before.setAllowedDomains(List.of("foo.com", "foo.com", "bar.com"));
+        var after = mcpImage();
+        after.setAllowedDomains(List.of("foo.com", "bar.com"));
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_allowedDomainsNullVsEmpty_returnsTrue() {
+        var before = mcpImage();
+        before.setAllowedDomains(null);
+        var after = mcpImage();
+        after.setAllowedDomains(new ArrayList<>());
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isTrue();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_allowedDomainsMembershipChanged_returnsFalse() {
+        var before = mcpImage();
+        before.setAllowedDomains(List.of("foo.com", "bar.com"));
+        var after = mcpImage();
+        after.setAllowedDomains(List.of("foo.com", "qux.com"));
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    // --- MCP transportType ------------------------------------------------
+
+    @Test
+    void hasSameBuildAffectingFields_mcpTransportTypeChanged_returnsFalse() {
+        var before = mcpImage();
+        before.setTransportType(McpTransportType.REMOTE);
+        var after = mcpImage();
+        after.setTransportType(McpTransportType.LOCAL);
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isFalse();
+    }
+
+    @Test
+    void hasSameBuildAffectingFields_mcpTransportTypeEqual_returnsTrue() {
+        var before = mcpImage();
+        before.setTransportType(McpTransportType.REMOTE);
+        var after = mcpImage();
+        after.setTransportType(McpTransportType.REMOTE);
+
+        assertThat(before.hasSameBuildAffectingFields(after)).isTrue();
+    }
+
+    // --- helpers ----------------------------------------------------------
+
+    private static McpImageDefinition mcpImage() {
+        return McpImageDefinition.builder()
+                .name("image")
+                .version("1.0.0")
+                .source(dockerSource())
+                .allowedDomains(List.of("foo.com"))
+                .imageBuilder(ImageBuilder.BUILDKIT_ROOTLESS)
+                .transportType(McpTransportType.REMOTE)
+                .build();
+    }
+
+    private static DockerImageSource dockerSource() {
+        return new DockerImageSource("http://test-uri", List.of("entry1"), null);
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes to #303

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- New behavior: built image definitions (BUILD_SUCCESSFUL) can now have their description, author, topics, and license updated without invalidating the built image. Any change to build-affecting fields is still rejected, and images currently building remain read-only.                                                                      
- Scope of the change: the "did build inputs change?" check lives on the ImageDefinition domain model (with order-insensitive allowedDomains comparison), the service routes meta-only updates through a dedicated mapper/repository path that preserves build state, unit and functional tests cover the new behavior, and specs/image-definitions/spec.md documents it. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.