### PR TITLE
chore: improve claude & spec-kit configuration

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,7 +1,7 @@
 <!-- Sync Impact Report
 Version change: 1.2.2 → 1.4.0 (MINOR: per-directory CLAUDE.md acknowledgment, Capability ↔ numbered cross-link rule, tech-stack reframe, inline enforcement tags, soften CONFIG_REST_SECURITY_MODE, expanded numbered-spec lifecycle, Out-of-Scope + Amendment History sections)
 Modified sections:
-  - Tech Stack (reframed: build.gradle is canonical for versions; this section pins only constitutionally-significant libs; added ArchUnit, Hibernate Envers, Commons Lang3/Collections4 since rules cite them; documented actuator 3.5.12 as a deliberate BOM override; corrected log4j-core to 2.25.4; corrected Lombok plugin wording; pinned base package)
+  - Tech Stack (reframed: build.gradle is canonical for versions; this section pins only constitutionally-significant libs; added ArchUnit, Hibernate Envers, Commons Lang3/Collections4 since rules cite them; documented actuator 3.5.14 as a deliberate BOM override; corrected log4j-core to 2.25.4; corrected Lombok plugin wording; pinned base package)
   - Architecture Principles II (separated `*JpaRepository` from `*Repository` `@Transactional` semantics)
   - Architecture Principles III + Anti-pattern #9 (clarified "polling" = K8s-API polling; scheduled tasks operating on local state are out of scope)
   - Architecture Principles IV (aligned `@LogExecution` Spring-component list with what ArchUnit actually enforces — added `@Repository`, dropped unused `@Controller`)
@@ -30,7 +30,7 @@ The base package for all production sources MUST be `com.epam.aidial.deployment.
 
 Constitutionally-significant libraries (any upgrade MUST go through a PR with a security or feature rationale):
 
-- **Runtime**: Java 21, Spring Boot 3.5.10, Gradle 8.13. `spring-boot-starter-actuator` is pinned to 3.5.12 as a **deliberate override** of the BOM; the rationale (security/feature) MUST be recorded in the build file at bump time.
+- **Runtime**: Java 21, Spring Boot 3.5.10, Gradle 8.13. `spring-boot-starter-actuator` is pinned to 3.5.14 as a **deliberate override** of the BOM; the rationale (security/feature) MUST be recorded in the build file at bump time.
 - **Code generation**: Lombok via `io.freefair.lombok` plugin 8.10, MapStruct 1.6.0
 - **Database migrations**: Flyway 11.14.0 (`flyway-core` for H2, `flyway-database-postgresql`, `flyway-sqlserver`)
 - **Kubernetes**: Fabric8 Kubernetes Client 7.5.2, Fabric8 Knative Client 7.5.2, `io.kubernetes:client-java` 22.0.0

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,7 +1,8 @@
 <!-- Sync Impact Report
-Version change: 1.2.1 → 1.2.2 (PATCH: added single-source-of-truth rule for configuration property defaults)
-Modified sections: Key Patterns (added Configuration property defaults rule)
-Added: Rule that @ConfigurationProperties field defaults MUST be declared only in application.yml, not duplicated in Java code
+Version change: 1.2.2 → 1.3.0 (MINOR: per-directory CLAUDE.md layered-docs acknowledgment + new spec-kit workflow rule for Capability cross-links)
+Modified sections:
+  - Governance (added paragraph about per-directory CLAUDE.md files)
+  - spec-kit Workflow Rules (added Capability ↔ numbered cross-link rule)
 Templates requiring updates:
   ✅ .specify/memory/constitution.md (this file)
   ✅ No template changes needed — speckit reads constitution directly
@@ -226,6 +227,8 @@ The following MUST NOT appear in new code. PRs introducing these patterns MUST b
 
 - **No per-feature checklists**: Do NOT generate `checklists/requirements.md` inside individual feature directories via `/speckit.checklist`. The generic checklist adds no per-feature value and creates redundant files. If a project-wide checklist is needed, maintain a single one in `specs/`.
 
+- **Capability ↔ numbered cross-links**: Numbered specs under `specs/NNN-<short-name>/spec.md` MUST declare a `**Capability**:` field directly under `**Status**:` (the convention is recorded in root `CLAUDE.md`). When a numbered feature ships, the matching capability spec MUST be updated and gain an `Implemented via NNN-<feature>` reference near the affected Requirement. Capability specs MAY reference in-flight numbered specs as `Pending: NNN-<feature>` notes; these MUST be removed or upgraded to `Implemented via …` when the feature ships.
+
 ## Tooling Commands
 
 | Command | Purpose |
@@ -246,6 +249,8 @@ considering the task done. Use `./gradlew testFast` to run tests during developm
 
 This constitution is the authoritative source of architectural truth for the DIAL Deployment Manager Backend. It supersedes any conflicting guidance in PR comments, local convention notes, or informal team agreements.
 
+Per-directory `CLAUDE.md` files exist for each architectural layer (`web/`, `service/`, `dao/`, `kubernetes/`, `configuration/`) and the migration trees; they restate this constitution's rules in local form and add subpackage navigation. The constitution remains the single source of truth — local files MUST NOT contradict it.
+
 **Amendment procedure**:
 1. Raise a PR with changes to this file; at least one approval required.
 2. Include a migration note if the amendment changes existing code patterns (link to a follow-up issue for affected code).
@@ -258,4 +263,4 @@ This constitution is the authoritative source of architectural truth for the DIA
 
 **Compliance review**: All PRs MUST be checked against this constitution. Automated checks (Checkstyle, `-Werror`) enforce code style sections; architectural sections are enforced via PR review.
 
-**Version**: 1.2.2 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-03-19
+**Version**: 1.3.0 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-04-29

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,34 +1,50 @@
 <!-- Sync Impact Report
-Version change: 1.2.2 → 1.3.0 (MINOR: per-directory CLAUDE.md layered-docs acknowledgment + new spec-kit workflow rule for Capability cross-links)
+Version change: 1.3.0 → 1.4.0 (MINOR: tech-stack reframe, inline enforcement tags, soften CONFIG_REST_SECURITY_MODE, expanded numbered-spec lifecycle, Out-of-scope + Amendment History sections)
 Modified sections:
-  - Governance (added paragraph about per-directory CLAUDE.md files)
-  - spec-kit Workflow Rules (added Capability ↔ numbered cross-link rule)
+  - Tech Stack (reframed: build.gradle is canonical for versions; this section pins only constitutionally-significant libs; added ArchUnit, Hibernate Envers, Commons Lang3/Collections4 since rules cite them; documented actuator 3.5.12 as a deliberate BOM override; corrected log4j-core to 2.25.4; corrected Lombok plugin wording; pinned base package)
+  - Architecture Principles II (separated `*JpaRepository` from `*Repository` `@Transactional` semantics)
+  - Architecture Principles III + Anti-pattern #9 (clarified "polling" = K8s-API polling; scheduled tasks operating on local state are out of scope)
+  - Architecture Principles IV (aligned `@LogExecution` Spring-component list with what ArchUnit actually enforces — added `@Repository`, dropped unused `@Controller`)
+  - Architecture Principles V (softened production CONFIG_REST_SECURITY_MODE to SHOULD with ops-policy framing; provider list moved to security capability spec)
+  - Naming Conventions, Code Style, API Conventions, Anti-Patterns, Patterns, Testing (added inline `(Checkstyle)` / `(ArchUnit)` / `(review)` enforcement tags)
+  - Anti-Patterns (deduped #4 to reference Principle II; reworded #5/#9 likewise)
+  - API Conventions (strengthened base-path uniqueness to invariants)
+  - spec-kit Workflow Rules (added Cancelled / Superseded numbered-spec statuses; added `/speckit.checklist` cleanup guidance)
+  - Tooling Commands (added `./gradlew bootRun`)
+  - Governance (added Out-of-Scope section, Amendment History footer, enforcement-mechanism legend)
 Templates requiring updates:
   ✅ .specify/memory/constitution.md (this file)
   ✅ No template changes needed — speckit reads constitution directly
   ✅ No [PLACEHOLDER] tokens remain
-Follow-up TODOs: none
+Follow-up TODOs:
+  - jjwt 0.9.1 (test-only) is out-of-scope for constitution; track upgrade in dep backlog
 -->
 
 # DIAL Deployment Manager Backend Constitution
 
 ## Tech Stack
 
-The project MUST use the following canonical versions. Any upgrade MUST go through a PR with a security or feature rationale.
+`build.gradle` and `gradle.properties` are the canonical record of dependency versions. This section pins **only the libraries whose presence or version is referenced by a constitutional rule** — anything else lives in the build files and may be bumped without amending this document.
 
-- **Runtime**: Java 21, Spring Boot 3.5.10, Gradle 8.13
-- **Code generation**: Lombok 8.10 (freefair plugin), MapStruct 1.6.0
-- **Database migrations**: Flyway 11.14.0 (flyway-core for H2, flyway-database-postgresql, flyway-sqlserver)
-- **Kubernetes**: Fabric8 Kubernetes Client 7.5.2, Fabric8 Knative Client 7.5.2, io.kubernetes:client-java 22.0.0
+The base package for all production sources MUST be `com.epam.aidial.deployment.manager`.
+
+Constitutionally-significant libraries (any upgrade MUST go through a PR with a security or feature rationale):
+
+- **Runtime**: Java 21, Spring Boot 3.5.10, Gradle 8.13. `spring-boot-starter-actuator` is pinned to 3.5.12 as a **deliberate override** of the BOM; the rationale (security/feature) MUST be recorded in the build file at bump time.
+- **Code generation**: Lombok via `io.freefair.lombok` plugin 8.10, MapStruct 1.6.0
+- **Database migrations**: Flyway 11.14.0 (`flyway-core` for H2, `flyway-database-postgresql`, `flyway-sqlserver`)
+- **Kubernetes**: Fabric8 Kubernetes Client 7.5.2, Fabric8 Knative Client 7.5.2, `io.kubernetes:client-java` 22.0.0
 - **Serialization**: Jackson 2.21.1 (enforced via buildscript constraint)
-- **Logging**: Log4j2 — `log4j-core` 2.25.3, `log4j-slf4j2-impl` 2.24.3, `log4j-jul` 2.24.3; spring-boot-starter-logging MUST be excluded globally
-- **Observability**: OpenTelemetry SDK + OTLP exporter, opentelemetry-spring-boot-starter 2.12.0, Micrometer + Prometheus
-- **Caching**: Caffeine 3.2.3 via spring-boot-starter-cache
+- **Logging**: Log4j2 — `log4j-core` 2.25.4, `log4j-slf4j2-impl` 2.24.3, `log4j-jul` 2.24.3; `spring-boot-starter-logging` MUST be excluded globally
+- **Observability**: OpenTelemetry SDK + OTLP exporter, `opentelemetry-spring-boot-starter` 2.12.0, Micrometer + Prometheus
+- **Caching**: Caffeine 3.2.3 via `spring-boot-starter-cache`
 - **Distributed locking**: ShedLock 6.3.0 (JDBC provider)
 - **API docs**: SpringDoc OpenAPI 2.8.5
-- **Security**: Spring Security + OAuth2 Resource Server; Azure Identity 1.18.0; supported providers: azure, keycloak, auth0, okta, cognito
-- **Databases supported**: H2 2.3.232 (dev/test), PostgreSQL 42.7.8, SQL Server 13.2.1 (mssql-jdbc)
-- **Code quality**: Checkstyle 10.21.4 (Google Java Style profile), `-Werror` on all Java compilation
+- **Security**: Spring Security + OAuth2 Resource Server; Azure Identity 1.18.0. The supported OIDC provider list lives in `specs/security/spec.md`.
+- **Databases supported**: H2 2.3.232 (dev/test), PostgreSQL 42.7.8, SQL Server 13.2.1 (`mssql-jdbc`)
+- **Auditing**: Hibernate Envers — anchors the `auditing` capability spec (numbered feature 014)
+- **Code quality**: Checkstyle 10.21.4 (Google Java Style profile), `-Werror` on all Java compilation, ArchUnit 1.3.0 (architectural rules in `ArchitectureTest`)
+- **Style helpers**: Apache Commons Lang3 3.18.0 and Commons Collections4 4.5.0-M3 — Code Style mandates their `StringUtils` and `CollectionUtils` over inline null-and-empty checks
 
 ## Architecture Principles
 
@@ -43,98 +59,101 @@ web (controller / handler / dto / mapper)
     → kubernetes (informer / knative / nim / kserve / event)
 ```
 
-- `web` layer MUST NOT call `dao` or `kubernetes` directly.
-- `service` layer MUST NOT be called by `dao` or `kubernetes`.
-- `kubernetes` package MUST be the only place Fabric8/io.kubernetes API types appear in non-configuration code.
+- `web` layer MUST NOT call `dao` or `kubernetes` directly. — *(ArchUnit)*
+- `service` layer MUST NOT be called by `dao` or `kubernetes`. — *(ArchUnit)*
+- `kubernetes` package MUST be the only place Fabric8 / `io.kubernetes` API types appear in non-configuration code. — *(review)*
 - Cross-layer shortcutting is a blocking PR review comment.
 
 ### II. Transactional Discipline
 
 - `@Transactional` MUST only appear on `service`-layer or `dao`-layer classes or their methods.
-- Controllers MUST NOT carry `@Transactional`.
-- DAO `@Transactional` is permitted on repository wrapper methods (e.g., custom query methods in `*Repository` classes) where transaction boundaries are inherent to the data access operation.
+- Controllers MUST NOT carry `@Transactional`. — *(ArchUnit)*
+- Spring Data `*JpaRepository` interfaces inherit framework-managed transactions; manual `@Transactional` is unnecessary and SHOULD NOT be added to them.
+- DAO `@Transactional` is permitted on **`*Repository` wrapper methods** (custom query methods that combine multiple JPA operations) where transaction boundaries are inherent to the data access operation. — *(review)*
 - Propagation and isolation overrides require an explanatory comment.
 
 ### III. Kubernetes Isolation
 
-- All calls that create, update, delete, or read Kubernetes resources MUST live in the `kubernetes/` package.
-- Fabric8 informers are the canonical mechanism for watching K8s state changes; polling loops are forbidden.
+- All calls that create, update, delete, or read Kubernetes resources MUST live in the `kubernetes/` package. — *(review)*
+- Fabric8 informers are the canonical mechanism for watching K8s state changes; **K8s-API polling loops** (repeatedly fetching resource state via the client to detect change) are forbidden. ShedLock-driven scheduled tasks that operate on local state (e.g., cleanup jobs) are not "polling" in this sense.
 
 ### IV. Observability First
 
-- `@LogExecution` MUST be placed on every Spring component class (`@Service`, `@Component`, `@Controller`, `@RestController`).
+- `@LogExecution` MUST be placed on every Spring component class — `@RestController`, `@Service`, `@Repository`, `@Component`. — *(ArchUnit: `ArchitectureTest`)*
 - All telemetry signals (traces, metrics, logs) MUST flow through OpenTelemetry; direct log statements in business logic are acceptable only for debug-level context.
 - Prometheus metrics are exposed via Actuator; custom `MeterRegistry` registrations follow existing patterns in `configuration/`.
 
 ### V. Security by Configuration
 
-- Default security mode is `none`; production deployments MUST set `CONFIG_REST_SECURITY_MODE` to `oidc` or `basic`.
+- Default security mode is `none`; production deployments SHOULD set `CONFIG_REST_SECURITY_MODE` to `oidc` or `basic`. This is **operator policy, not a code-level invariant** — there is no startup guard. The chosen mode MUST be documented in the deployment runbook.
 - Sensitive environment variables MUST be converted to Kubernetes Secrets automatically by the pipeline; they MUST NOT be stored in ConfigMaps or committed to git.
-- JWT validation is multi-provider: each provider configured independently under `providers.{name}.*`.
+- JWT validation is multi-provider: each provider is configured independently under `providers.{name}.*`. The supported provider list lives in `specs/security/spec.md`.
 
 ## Naming Conventions
 
-| Artifact | Pattern | Example |
-|---|---|---|
-| Request/response DTO | `*Dto`, `*RequestDto` | `DeploymentDto`, `CreateDeploymentRequestDto` |
-| Web layer mapper (MapStruct) | `*DtoMapper` | `DeploymentDtoMapper` |
-| Persistence mapper (MapStruct) | `Persistence*Mapper` | `PersistenceDeploymentMapper` |
-| JPA entity | `*Entity` | `DeploymentEntity` |
-| Spring Data JPA repository | `*JpaRepository` | `DeploymentJpaRepository` |
-| Domain/DAO repository wrapper | `*Repository` | `DeploymentRepository` |
-| Service | `*Service` | `DeploymentService` |
-| Controller | `*Controller` | `DeploymentController` |
-| Functional / integration test | `*FunctionalTest` | `DeploymentFunctionalTest` |
-| Unit test | `*Test` | `DeploymentServiceTest` |
+The patterns below are enforced by review unless tagged otherwise.
 
-Package names MUST be all-lowercase with no underscores (enforced by Checkstyle `PackageName`).
+| Artifact | Pattern | Example | Enforcement |
+|---|---|---|---|
+| Request/response DTO | `*Dto`, `*RequestDto` | `DeploymentDto`, `CreateDeploymentRequestDto` | review |
+| Web layer mapper (MapStruct) | `*DtoMapper` | `DeploymentDtoMapper` | review (MapStruct `componentModel="spring"` → ArchUnit) |
+| Persistence mapper (MapStruct) | `Persistence*Mapper` | `PersistenceDeploymentMapper` | review |
+| JPA entity | `*Entity` | `DeploymentEntity` | review |
+| Spring Data JPA repository | `*JpaRepository` | `DeploymentJpaRepository` | ArchUnit (placement) |
+| Domain/DAO repository wrapper | `*Repository` | `DeploymentRepository` | ArchUnit (placement) |
+| Service | `*Service` | `DeploymentService` | review |
+| Controller | `*Controller` | `DeploymentController` | review |
+| Functional / integration test | `*FunctionalTest` | `DeploymentFunctionalTest` | review |
+| Unit test | `*Test` | `DeploymentServiceTest` | review |
+
+Package names MUST be all-lowercase with no underscores. — *(Checkstyle: `PackageName`)*
 
 ## Code Style
 
-- **Style guide**: Google Java Style, enforced by Checkstyle 10.21.4.
-- **Line length**: 180 characters maximum (enforced).
-- **Compiler**: `-Werror` — all warnings are errors; no suppression without justification.
-- **Imports**: No wildcard (`*`) imports (enforced). Import order: third-party → standard Java → static, alphabetically within groups.
-- **FQNs in method bodies**: Forbidden; always use a proper import.
-- **Local variables**: SHOULD use `var` where the type is obvious from the right-hand side.
-- **Braces**: K&R style; mandatory for all control flow statements.
-- **Indentation**: 4 spaces; no tabs.
-- **One statement per line** and **one top-level class per file** enforced.
-- **Collection emptiness checks**: Use `CollectionUtils.isEmpty()` / `CollectionUtils.isNotEmpty()` (`org.apache.commons.collections4.CollectionUtils`) instead of `collection != null && !collection.isEmpty()` or similar inline null-and-empty checks.
-- **String emptiness checks**: Use Apache Commons `StringUtils.isEmpty()` / `StringUtils.isNotEmpty()` / `StringUtils.isBlank()` / `StringUtils.isNotBlank()` (`org.apache.commons.lang3.StringUtils`) instead of inline null-and-empty checks on strings.
+- **Style guide**: Google Java Style. — *(Checkstyle 10.21.4)*
+- **Line length**: 180 characters maximum. — *(Checkstyle: `LineLength`)*
+- **Compiler**: `-Werror` — all warnings are errors; no suppression without justification. — *(compiler)*
+- **Imports**: No wildcard (`*`) imports. Import order: third-party → standard Java → static, alphabetically within groups. — *(Checkstyle: `AvoidStarImport`, `CustomImportOrder`)*
+- **FQNs in method bodies**: Forbidden; always use a proper import. — *(review)*
+- **Local variables**: SHOULD use `var` where the type is obvious from the right-hand side. — *(review)*
+- **Braces**: K&R style; mandatory for all control flow statements. — *(Checkstyle: `LeftCurly`, `NeedBraces`)*
+- **Indentation**: 4 spaces; no tabs. — *(Checkstyle: `FileTabCharacter`)*
+- **One statement per line** and **one top-level class per file**. — *(Checkstyle: `OneTopLevelClass`)*
+- **Collection emptiness checks**: Use `CollectionUtils.isEmpty()` / `CollectionUtils.isNotEmpty()` (`org.apache.commons.collections4.CollectionUtils`) instead of `collection != null && !collection.isEmpty()` or similar inline null-and-empty checks. — *(review)*
+- **String emptiness checks**: Use Apache Commons `StringUtils.isEmpty()` / `StringUtils.isNotEmpty()` / `StringUtils.isBlank()` / `StringUtils.isNotBlank()` (`org.apache.commons.lang3.StringUtils`) instead of inline null-and-empty checks on strings. — *(review)*
 
 ## API Conventions
 
-- **Public API base path**: `/api/v1/`
-- **Internal API base path**: `/api/internal/v1/`
-- **Error response schema**: `ErrorView` — MUST include `message`, `status`, and `traceparent` (from OTel span context). Full fields: `path`, `method`, `status`, `error`, `message`, `traceparent`.
-- **OpenAPI annotations**: Every endpoint method MUST carry `@Operation` (SpringDoc) with `summary` and relevant `@ApiResponse` annotations.
-- **Pagination**: List endpoints returning potentially large datasets MUST support pagination via Spring's `Pageable`.
-- **SSE endpoints**: Real-time status updates (builds, deployments) MUST use `SseEmitter` and follow existing patterns in `web/handler/`.
+- **Public API base path**: `/api/v1/` — no public endpoint may live outside this prefix. — *(review)*
+- **Internal API base path**: `/api/internal/v1/` — no internal endpoint may live outside this prefix. — *(review)*
+- **Error response schema**: `ErrorView` — MUST include `message`, `status`, and `traceparent` (from OTel span context). Full fields: `path`, `method`, `status`, `error`, `message`, `traceparent`. — *(review)*
+- **OpenAPI annotations**: Every endpoint method MUST carry `@Operation` (SpringDoc) with `summary` and relevant `@ApiResponse` annotations. — *(review)*
+- **Pagination**: List endpoints returning potentially large datasets MUST support pagination via Spring's `Pageable`. — *(review)*
+- **SSE endpoints**: Real-time status updates (builds, deployments) MUST use `SseEmitter` and follow existing patterns in `web/handler/`. — *(review)*
 - **Health check**: Standard Spring Boot Actuator at `/actuator/health`; custom health indicators are allowed in `configuration/`.
 
 ## Testing Conventions
 
-- **Test method naming**: `shouldDoX()` for happy paths, `shouldFailDoX_whenY()` for failure scenarios.
+- **Test method naming**: `shouldDoX()` for happy paths, `shouldFailDoX_whenY()` for failure scenarios. — *(review)*
 - **Database selection**: Controlled by `DATASOURCE_VENDOR` env var; Testcontainers for Postgres and SQL Server in CI, H2 for lightweight local runs.
-- **Test infrastructure**: Testcontainers 1.21.3; `@Testcontainers` + `@Container` for container lifecycle.
-- **Assertions**: AssertJ preferred (`assertThat(...)`); raw JUnit `assertEquals` is discouraged.
-- **Functional tests**: MUST extend or mirror `H2FunctionalTests` / `PostgresFunctionalTests` / `SqlServerFunctionalTests` base patterns; cover all supported vendors where SQL behavior may differ.
+- **Test infrastructure**: Testcontainers; `@Testcontainers` + `@Container` for container lifecycle.
+- **Assertions**: AssertJ preferred (`assertThat(...)`); raw JUnit `assertEquals` is discouraged. — *(review)*
+- **Functional tests**: MUST extend or mirror `H2FunctionalTests` / `PostgresFunctionalTests` / `SqlServerFunctionalTests` base patterns; cover all supported vendors where SQL behavior may differ. — *(review)*
 - **Security tests**: Use `spring-security-test` for authenticated endpoint tests; JWT tokens generated with `io.jsonwebtoken:jjwt`.
-- **No mocking of K8s calls in functional tests**: Use Testcontainers or in-memory stubs defined in `src/test/`.
+- **No mocking of K8s calls in functional tests**: Use Testcontainers or in-memory stubs defined in `src/test/`. — *(review)*
 
 ## Key Patterns
 
 **`@LogExecution`** — Class-level annotation MUST appear on every Spring component (`@RestController`,
 `@Service`, `@Repository`, `@Component`). Import:
 `com.epam.aidial.deployment.manager.configuration.logging.LogExecution`. Wired via
-`CustomizableTraceInterceptor` in `configuration/logging/`. Enforced automatically by ArchUnit
-(`ArchitectureTest` — see that class for the precise set of exclusions and known legacy gaps).
+`CustomizableTraceInterceptor` in `configuration/logging/`. *(ArchUnit: `ArchitectureTest`)* — see that
+class for the precise set of exclusions and known legacy gaps.
 
-**MapStruct** — All mapper interfaces MUST declare `componentModel = "spring"`.
+**MapStruct** — All mapper interfaces MUST declare `componentModel = "spring"`. *(ArchUnit)*
 `subclassExhaustiveStrategy = SubclassExhaustiveStrategy.RUNTIME_EXCEPTION` SHOULD be included
 when the mapper handles polymorphic types; it MAY be omitted for simple mappers that don't
-involve subclass mappings.
+involve subclass mappings. *(review)*
 ```java
 @Mapper(componentModel = "spring",
         subclassExhaustiveStrategy = SubclassExhaustiveStrategy.RUNTIME_EXCEPTION) // include when mapping polymorphic types
@@ -165,14 +184,14 @@ Java field initializers in `*Properties` classes MUST NOT duplicate these defaul
 fields MUST be declared without initializers (e.g., `private int maxRetries;`, not
 `private int maxRetries = 3;`). This prevents divergence between the YAML and Java
 defaults, which is hard to detect and can cause subtle runtime differences depending
-on profile loading order.
+on profile loading order. — *(review)*
 
 **Configuration documentation** — `docs/configuration.md` is manually maintained. It MUST be
 updated whenever a feature adds new `@ConfigurationProperties` fields, new environment variables,
 or changes to existing `application.yml` entries. **Speckit flow**: any feature spec that
 introduces or modifies application configuration MUST include a task to update
 `docs/configuration.md` with the affected properties — env var name, default value, and
-description.
+description. — *(review)*
 
 ## Multi-Vendor Database Pattern
 
@@ -191,7 +210,7 @@ Database vendor is selected at runtime via the `DATASOURCE_VENDOR` environment v
 **Flyway configuration**:
 - `baseline-on-migrate: true`
 - `baseline-version: 1.1`
-- JPA `ddl-auto: validate` — Flyway owns schema; Hibernate MUST NOT create or alter tables
+- JPA `ddl-auto: validate` — Flyway owns schema; Hibernate MUST NOT create or alter tables. — *(review)*
 
 When adding a migration, create the corresponding file in all applicable vendor directories
 (H2, POSTGRES, MS_SQL_SERVER) unless the migration is vendor-specific by design.
@@ -212,22 +231,29 @@ migrations via `./gradlew generateDbSchema`. This file MUST NOT be edited manual
 
 The following MUST NOT appear in new code. PRs introducing these patterns MUST be rejected:
 
-1. **Business logic in entities** — `*Entity` classes are pure data holders; no service calls, computed state, or Lombok `@Builder` default methods with side effects.
-2. **Silent exception swallowing** — Every `catch` block MUST either rethrow, log with context, or explicitly document why suppression is safe.
-3. **Generic `Exception` catch** — Catch specific exception types. `catch (Exception e)` is allowed only in top-level exception handlers (`DefaultExceptionHandler`).
-4. **`@Transactional` on controllers** — Violates Transactional Discipline (Principle II). DAO-layer `@Transactional` is permitted on repository wrapper methods.
-5. **Kubernetes API calls from the service layer** — Violates Kubernetes Isolation (Principle III).
-6. **Wildcard imports** — Violates Code Style; blocked by Checkstyle.
-7. **Direct `System.out.println` or `e.printStackTrace()`** — Use SLF4J logger via Log4j2.
-8. **Hard-coded credentials or secrets** — All secrets via environment variables or Kubernetes Secrets.
-9. **Polling loops for K8s state** — Use Fabric8 informers.
-10. **`ddl-auto` values other than `validate`** — Flyway owns schema; JPA must not create or update tables.
+1. **Business logic in entities** — `*Entity` classes are pure data holders; no service calls, computed state, or Lombok `@Builder` default methods with side effects. — *(review)*
+2. **Silent exception swallowing** — Every `catch` block MUST either rethrow, log with context, or explicitly document why suppression is safe. — *(review)*
+3. **Generic `Exception` catch** — Catch specific exception types. `catch (Exception e)` is allowed only in top-level exception handlers (`DefaultExceptionHandler`). — *(review)*
+4. **`@Transactional` on controllers** — See Principle II. — *(ArchUnit)*
+5. **Kubernetes API calls from the service layer** — See Principle III. — *(review)*
+6. **Wildcard imports** — Violates Code Style. — *(Checkstyle: `AvoidStarImport`)*
+7. **Direct `System.out.println` or `e.printStackTrace()`** — Use SLF4J logger via Log4j2. — *(review)*
+8. **Hard-coded credentials or secrets** — All secrets via environment variables or Kubernetes Secrets. — *(review)*
+9. **K8s-API polling loops** — Use Fabric8 informers. (Scheduled tasks operating on local state, e.g., ShedLock-driven cleanup, are not "polling" in this sense — see Principle III.) — *(review)*
+10. **`ddl-auto` values other than `validate`** — Flyway owns schema; JPA must not create or update tables. — *(review)*
 
 ## spec-kit Workflow Rules
 
-- **No per-feature checklists**: Do NOT generate `checklists/requirements.md` inside individual feature directories via `/speckit.checklist`. The generic checklist adds no per-feature value and creates redundant files. If a project-wide checklist is needed, maintain a single one in `specs/`.
+- **No per-feature checklists**: Do NOT generate `checklists/requirements.md` inside individual feature directories via `/speckit.checklist`. The generic checklist adds no per-feature value and creates redundant files. If `/speckit.checklist` runs and creates a `checklists/` directory, delete it before committing. If a project-wide checklist is needed, maintain a single one in `specs/`.
 
-- **Capability ↔ numbered cross-links**: Numbered specs under `specs/NNN-<short-name>/spec.md` MUST declare a `**Capability**:` field directly under `**Status**:` (the convention is recorded in root `CLAUDE.md`). When a numbered feature ships, the matching capability spec MUST be updated and gain an `Implemented via NNN-<feature>` reference near the affected Requirement. Capability specs MAY reference in-flight numbered specs as `Pending: NNN-<feature>` notes; these MUST be removed or upgraded to `Implemented via …` when the feature ships.
+- **Numbered-spec lifecycle**: The `**Status**:` field on `specs/NNN-<short-name>/spec.md` MUST take one of the following values:
+  - `Draft` — work in progress.
+  - `Implemented` — all P1+ stories shipped; matching capability spec(s) updated with `Implemented via NNN-<feature>` cross-reference.
+  - `Partially implemented — <reason>` — some stories deliberately deferred.
+  - `Cancelled — <reason>` — feature was dropped before shipping. Spec is retained as audit trail; no capability cross-link is created. Any `Pending: NNN-<feature>` notes in capability specs MUST be removed.
+  - `Superseded by NNN-<short-name>` — feature was rolled into or replaced by a later numbered spec. The successor spec MUST cross-link back to the predecessor. Once the successor's behavior is the default path, the affected capability spec is **rewritten** (not annotated) to describe only the current state.
+
+- **Capability ↔ numbered cross-links**: Numbered specs MUST declare a `**Capability**:` field directly under `**Status**:` (the convention is recorded in root `CLAUDE.md`). When a numbered feature ships, the matching capability spec MUST be updated and gain an `Implemented via NNN-<feature>` reference near the affected Requirement. Capability specs MAY reference in-flight numbered specs as `Pending: NNN-<feature>` notes; these MUST be removed or upgraded to `Implemented via …` when the feature ships, or removed when the feature is `Cancelled`.
 
 ## Tooling Commands
 
@@ -238,12 +264,25 @@ The following MUST NOT appear in new code. PRs introducing these patterns MUST b
 | `./gradlew checkstyleMain checkstyleTest` | Run Checkstyle on main and test sources |
 | `./gradlew clean build` | Full clean build (tests + Checkstyle) |
 | `./gradlew clean bootJar` | Build executable JAR without running tests |
+| `./gradlew bootRun` | Run the service locally on the JVM |
 | `./gradlew generateDbSchema` | Regenerate `docs/db-schema.md` from H2 Flyway migrations — run after any migration change |
 | `docker build -t deployment-manager .` | Build Docker image (two-stage: `gradle:8.13-jdk21-alpine` → `amazoncorretto:21-alpine`) |
 
 After any code change, always verify with `./gradlew checkstyleMain checkstyleTest` before
 considering the task done. Use `./gradlew testFast` to run tests during development; a clean
 `./gradlew clean build` (full suite) is the gate for PR readiness.
+
+## Out of Scope
+
+This constitution governs the backend Java service. The following areas are intentionally **not** covered here and have their own sources of truth:
+
+- Frontend / UI conventions
+- Deployment topology, infrastructure-as-code, and ops runbooks
+- CI/CD pipeline mechanics (Jenkinsfile, GitHub Actions workflows)
+- Per-environment configuration values (live in deployment manifests, not in this repo)
+- Third-party library versions beyond the constitutionally-significant set above — `build.gradle` and `gradle.properties` are canonical
+
+Capability-level behavior, contracts, and invariants live in `specs/<capability>/spec.md`; the constitution intentionally avoids restating them.
 
 ## Governance
 
@@ -254,13 +293,25 @@ Per-directory `CLAUDE.md` files exist for each architectural layer (`web/`, `ser
 **Amendment procedure**:
 1. Raise a PR with changes to this file; at least one approval required.
 2. Include a migration note if the amendment changes existing code patterns (link to a follow-up issue for affected code).
-3. Run `/speckit.constitution` via Claude Code to propagate changes to dependent templates.
+3. Update the Sync Impact Report block at the top of this file and append a row to the Amendment History table below.
+4. Run `/speckit.constitution` if the amendment affects content speckit reads directly (currently this file only).
 
 **Versioning policy**:
 - MAJOR: Removal or redefinition of an existing principle (breaks existing code).
 - MINOR: New principle, section, or materially expanded guidance.
 - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
 
-**Compliance review**: All PRs MUST be checked against this constitution. Automated checks (Checkstyle, `-Werror`) enforce code style sections; architectural sections are enforced via PR review.
+**Compliance review**: All PRs MUST be checked against this constitution. Inline enforcement tags identify the mechanism for each rule:
+- *(Checkstyle)* / *(compiler)* — blocked at build time.
+- *(ArchUnit)* — verified by `ArchitectureTest`, runs as part of the test suite.
+- *(review)* — relies on PR review; no automated check.
 
-**Version**: 1.3.0 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-04-29
+## Amendment History
+
+| Version | Date | Summary |
+|---|---|---|
+| 1.4.0 | 2026-04-30 | Reframed Tech Stack (build.gradle canonical); added inline enforcement tags; softened CONFIG_REST_SECURITY_MODE to SHOULD; aligned `@LogExecution` Spring-component list with ArchUnit; deduped Anti-pattern #4; clarified K8s-API polling vs scheduled tasks; expanded numbered-spec lifecycle (Cancelled, Superseded); added Out of Scope and Amendment History sections |
+| 1.3.0 | 2026-04-29 | Per-directory CLAUDE.md acknowledgment; added Capability ↔ numbered-spec cross-link rule |
+| ≤1.2.2 | — | See `git log .specify/memory/constitution.md` |
+
+**Version**: 1.4.0 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-04-30

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,5 +1,5 @@
 <!-- Sync Impact Report
-Version change: 1.3.0 → 1.4.0 (MINOR: tech-stack reframe, inline enforcement tags, soften CONFIG_REST_SECURITY_MODE, expanded numbered-spec lifecycle, Out-of-scope + Amendment History sections)
+Version change: 1.2.2 → 1.4.0 (MINOR: per-directory CLAUDE.md acknowledgment, Capability ↔ numbered cross-link rule, tech-stack reframe, inline enforcement tags, soften CONFIG_REST_SECURITY_MODE, expanded numbered-spec lifecycle, Out-of-Scope + Amendment History sections)
 Modified sections:
   - Tech Stack (reframed: build.gradle is canonical for versions; this section pins only constitutionally-significant libs; added ArchUnit, Hibernate Envers, Commons Lang3/Collections4 since rules cite them; documented actuator 3.5.12 as a deliberate BOM override; corrected log4j-core to 2.25.4; corrected Lombok plugin wording; pinned base package)
   - Architecture Principles II (separated `*JpaRepository` from `*Repository` `@Transactional` semantics)
@@ -9,9 +9,9 @@ Modified sections:
   - Naming Conventions, Code Style, API Conventions, Anti-Patterns, Patterns, Testing (added inline `(Checkstyle)` / `(ArchUnit)` / `(review)` enforcement tags)
   - Anti-Patterns (deduped #4 to reference Principle II; reworded #5/#9 likewise)
   - API Conventions (strengthened base-path uniqueness to invariants)
-  - spec-kit Workflow Rules (added Cancelled / Superseded numbered-spec statuses; added `/speckit.checklist` cleanup guidance)
+  - spec-kit Workflow Rules (added Capability ↔ numbered cross-link rule; added Cancelled / Superseded numbered-spec statuses; added `/speckit.checklist` cleanup guidance)
   - Tooling Commands (added `./gradlew bootRun`)
-  - Governance (added Out-of-Scope section, Amendment History footer, enforcement-mechanism legend)
+  - Governance (added per-directory CLAUDE.md acknowledgment paragraph; added Out-of-Scope section, Amendment History footer, enforcement-mechanism legend)
 Templates requiring updates:
   ✅ .specify/memory/constitution.md (this file)
   ✅ No template changes needed — speckit reads constitution directly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,5 +68,5 @@ Where `<slug>` is the directory name under `specs/` that the feature belongs to 
 
 **When `/speckit.implement` finishes**, before reporting complete:
 1. Edit `specs/NNN-<short-name>/spec.md` to flip `**Status**:` from `Draft` to `Implemented` (or `Partially implemented — <reason>` if not all P1+ stories landed).
-2. Read the `**Capability**:` line; for each listed slug, open `specs/<slug>/spec.md` and update the affected Requirement(s)/Scenario(s) to match the shipped behaviour. Add a one-line `Implemented via NNN-<feature>` cross-reference near the changed Requirement.
+2. Read the `**Capability**:` line; for each listed slug, open `specs/<slug>/spec.md` and update the affected Requirement(s)/Scenario(s) to match the shipped behaviour. Add a one-line `Implemented via NNN-<feature>` cross-reference near the changed Requirement, and remove or upgrade any `Pending: NNN-<feature>` note for this feature.
 3. If the field is `N/A — creates new capability <slug>`, scaffold `specs/<slug>/spec.md` from the house style (use `specs/api-conventions/spec.md` as a model) and add a row to `specs/README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 All architecture rules, naming conventions, code style, patterns, and domain knowledge live in speckit docs. **Read these before making changes:**
 
 - **Constitution** (mandatory): `.specify/memory/constitution.md` — layered architecture, naming conventions, tech stack versions, key patterns, testing strategy
-- **Feature specs**: `specs/<feature>/spec.md` — domain behavior, API contracts, edge cases for each feature area
-- **Docs**: `docs/configuration.md` (env vars)
+- **Capability specs**: `specs/<capability>/spec.md` — per-area behavior and contracts; index in `specs/README.md`
+- **Numbered feature specs**: `specs/NNN-<feature>/` — speckit workflow artifacts (spec, plan, tasks) for in-flight features
+- **Per-directory CLAUDE.md**: each layer (`web/`, `service/`, `dao/`, `kubernetes/`, `configuration/`) and migration tree has a local CLAUDE.md with layer-specific rules and pointers to relevant capability specs. Read the one in the directory you're editing first.
+- **Docs**: `docs/configuration.md` (env vars), `docs/db-schema.md` (auto-generated, do not edit)
 
 ## Essential Commands
 
@@ -29,8 +31,44 @@ Run a single test class:
 
 This project uses speckit (`/speckit.*` slash commands) for feature development. The workflow is: specify → plan → tasks → implement. Feature specs in `specs/` and the constitution in `.specify/memory/constitution.md` are the authoritative references for how code should be structured.
 
-## Active Technologies
-- Java 21, Spring Boot 3.5.10, Gradle 8.13 + Fabric8 Kubernetes Client 7.5.2, NVIDIA NIM CRD (NIMService), MapStruct 1.6.0, Lombok 8.10 (013-nim-served-model-name)
+### Spec maintenance is part of every code change
 
-## Recent Changes
-- 013-nim-served-model-name
+When you change behaviour, contracts, or invariants documented in any `specs/<capability>/spec.md`, update that spec in the same change — it isn't optional polish. This applies to both speckit-driven work and ad-hoc edits.
+
+**Before reporting a code change as complete:**
+1. Skim `specs/README.md` to identify which capability spec(s) describe the area you touched.
+2. If a capability spec mentions the API/behaviour/invariant you changed, update the spec to match the new state.
+3. If you've checked and no spec update is needed, say so explicitly in your final summary so the user doesn't have to ask.
+
+A `Stop` hook (`.claude/hooks/check-spec-staleness.sh`) enforces this once per session: if significant source files changed without any spec update, it blocks with a list of likely capability specs to review. The block fires once per session — to release it, either update a spec or affirmatively state "no spec update needed because …" and try to stop again.
+
+### Speckit-vendored files are off-limits
+
+The following paths are vendored from github/spec-kit and **MUST NOT** be edited — they get overwritten on `specify update`:
+
+- `.specify/templates/*.md`
+- `.specify/extensions.yml`
+- `.specify/scripts/bash/*.sh`
+- `.claude/skills/speckit-*/SKILL.md`
+
+When you need to extend speckit behaviour (e.g. add metadata, change a workflow step), put the convention in user-owned files: root `CLAUDE.md`, `.specify/memory/constitution.md`, the `specs/` tree, or new (non-`speckit-*`-prefixed) skills/hooks under `.claude/`.
+
+### Numbered-spec hygiene
+
+Numbered feature specs under `specs/NNN-<short-name>/` are managed by speckit but the metadata Claude needs lives in user-owned conventions:
+
+**After running `/speckit.specify`**, immediately edit the freshly-created `specs/NNN-<short-name>/spec.md` to add a line directly under `**Status**: Draft`:
+
+```
+**Capability**: <slug>
+```
+
+Where `<slug>` is the directory name under `specs/` that the feature belongs to (e.g. `nim-deployments`, `image-builds`, `mcp-deployments`). Conventions:
+- For cross-cutting features that touch several capabilities, use a comma-separated list: `**Capability**: deployments, kubernetes-manifests`.
+- For features that introduce a brand-new capability: `**Capability**: N/A — creates new capability <new-slug>`.
+- Use `specs/README.md` as the source of valid slugs.
+
+**When `/speckit.implement` finishes**, before reporting complete:
+1. Edit `specs/NNN-<short-name>/spec.md` to flip `**Status**:` from `Draft` to `Implemented` (or `Partially implemented — <reason>` if not all P1+ stories landed).
+2. Read the `**Capability**:` line; for each listed slug, open `specs/<slug>/spec.md` and update the affected Requirement(s)/Scenario(s) to match the shipped behaviour. Add a one-line `Implemented via NNN-<feature>` cross-reference near the changed Requirement.
+3. If the field is `N/A — creates new capability <slug>`, scaffold `specs/<slug>/spec.md` from the house style (use `specs/api-conventions/spec.md` as a model) and add a row to `specs/README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,6 @@ When you change behaviour, contracts, or invariants documented in any `specs/<ca
 2. If a capability spec mentions the API/behaviour/invariant you changed, update the spec to match the new state.
 3. If you've checked and no spec update is needed, say so explicitly in your final summary so the user doesn't have to ask.
 
-A `Stop` hook (`.claude/hooks/check-spec-staleness.sh`) enforces this once per session: if significant source files changed without any spec update, it blocks with a list of likely capability specs to review. The block fires once per session — to release it, either update a spec or affirmatively state "no spec update needed because …" and try to stop again.
-
 ### Speckit-vendored files are off-limits
 
 The following paths are vendored from github/spec-kit and **MUST NOT** be edited — they get overwritten on `specify update`:

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.25.4'
     implementation 'org.apache.logging.log4j:log4j-jul:2.24.3'
 
-    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.5.12'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.5.12' // security fix — pinned above Spring Boot 3.5.10 BOM
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.opentelemetry:opentelemetry-sdk'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,7 +1,7 @@
 # Database Schema
 
 > Auto-generated from H2 Flyway migrations. Do not edit manually.
-> Generated at: 2026-04-29T15:11:01.052607Z
+> Generated at: 2026-04-21T13:35:17.766734900Z
 
 ## Tables
 

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,7 +1,7 @@
 # Database Schema
 
 > Auto-generated from H2 Flyway migrations. Do not edit manually.
-> Generated at: 2026-04-21T13:35:17.766734900Z
+> Generated at: 2026-04-29T15:11:01.052607Z
 
 ## Tables
 

--- a/specs/001-deployment-topics/spec.md
+++ b/specs/001-deployment-topics/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `001-deployment-topics`
 **Created**: 2026-03-05
 **Status**: Draft
+**Capability**: topics
 **Input**: User description: "It should be possible to add topics on deployments, similarly to image definitions"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/001-deployment-topics/spec.md
+++ b/specs/001-deployment-topics/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `001-deployment-topics`
 **Created**: 2026-03-05
-**Status**: Draft
+**Status**: Implemented
 **Capability**: topics
 **Input**: User description: "It should be possible to add topics on deployments, similarly to image definitions"
 

--- a/specs/002-deployment-command-args/spec.md
+++ b/specs/002-deployment-command-args/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `002-deployment-command-args`
 **Created**: 2026-03-09
 **Status**: Draft
+**Capability**: deployments
 **Input**: User description: "Support `command` and `args` configuration for all deployment types"
 **Source Issue**: [#204](https://github.com/epam/ai-dial-admin-deployment-manager-backend/issues/204)
 

--- a/specs/002-deployment-command-args/spec.md
+++ b/specs/002-deployment-command-args/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `002-deployment-command-args`
 **Created**: 2026-03-09
-**Status**: Draft
+**Status**: Implemented
 **Capability**: deployments
 **Input**: User description: "Support `command` and `args` configuration for all deployment types"
 **Source Issue**: [#204](https://github.com/epam/ai-dial-admin-deployment-manager-backend/issues/204)

--- a/specs/003-unified-deployment-source/spec.md
+++ b/specs/003-unified-deployment-source/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `003-unified-deployment-source`
 **Created**: 2026-03-10
-**Status**: Draft
+**Status**: Implemented
 **Capability**: deployments
 **Input**: User description: "Unified deployment source model with direct imageReference support for Knative deployments"
 

--- a/specs/003-unified-deployment-source/spec.md
+++ b/specs/003-unified-deployment-source/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `003-unified-deployment-source`
 **Created**: 2026-03-10
 **Status**: Draft
+**Capability**: deployments
 **Input**: User description: "Unified deployment source model with direct imageReference support for Knative deployments"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/004-store-service-name/spec.md
+++ b/specs/004-store-service-name/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `004-store-service-name`
 **Created**: 2026-03-11
 **Status**: Implemented
+**Capability**: deployments
 **Input**: User description: "Currently, we often rely on our naming conventions (K8sNamingUtils and IdExtractor) to define deployment by K8s objects and vice versa - it becomes a problem when 'resourceNamePrefix' changes, since existing K8s resources become lost. Deployment service (Knative/NIM/Kserve) name should be stored per each deployment (in deployment table) and used instead of id extraction."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/005-external-registry-ref/spec.md
+++ b/specs/005-external-registry-ref/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `005-external-registry-ref`
 **Created**: 2026-03-13
-**Status**: Draft
+**Status**: Implemented
 **Capability**: image-definitions
 **Input**: User description: "Store a ref/link to an external storage/registry inside general image/deployment sources (e.g. Docker image source, Git dockerfile source, direct image reference). These functional sources describe how to obtain an artifact but carry no information about where the artifact is catalogued — the external registry reference fills that gap for informational client purposes."
 

--- a/specs/005-external-registry-ref/spec.md
+++ b/specs/005-external-registry-ref/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `005-external-registry-ref`
 **Created**: 2026-03-13
 **Status**: Draft
+**Capability**: image-definitions
 **Input**: User description: "Store a ref/link to an external storage/registry inside general image/deployment sources (e.g. Docker image source, Git dockerfile source, direct image reference). These functional sources describe how to obtain an artifact but carry no information about where the artifact is catalogued — the external registry reference fills that gap for informational client purposes."
 
 ## Background

--- a/specs/006-config-export-preview/spec.md
+++ b/specs/006-config-export-preview/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `006-config-export-preview`
 **Created**: 2026-03-16
 **Status**: Draft
+**Capability**: export-import
 **Input**: User description: "Implement endpoint for config export preview. Request body should be the same as on export - ExportRequestDto. Response should be ExportConfigPreviewDto (new class) which has the following fields: List<String> globalImageBuildDomainWhitelist, List<ExportComponentInfoDto> imageDefinitions, List<ExportComponentInfoDto> deployments. New class ExportComponentInfoDto should have the following fields: String name, String displayName, String version, String description, ExportConfigComponentTypeDto type."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/006-config-export-preview/spec.md
+++ b/specs/006-config-export-preview/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `006-config-export-preview`
 **Created**: 2026-03-16
-**Status**: Draft
+**Status**: Implemented
 **Capability**: export-import
 **Input**: User description: "Implement endpoint for config export preview. Request body should be the same as on export - ExportRequestDto. Response should be ExportConfigPreviewDto (new class) which has the following fields: List<String> globalImageBuildDomainWhitelist, List<ExportComponentInfoDto> imageDefinitions, List<ExportComponentInfoDto> deployments. New class ExportComponentInfoDto should have the following fields: String name, String displayName, String version, String description, ExportConfigComponentTypeDto type."
 

--- a/specs/007-config-import-preview/spec.md
+++ b/specs/007-config-import-preview/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `007-config-import-preview`
 **Created**: 2026-03-16
-**Status**: Draft
+**Status**: Implemented
 **Capability**: export-import
 **Input**: User description: "Implement preview for config import. New endpoint POST /api/v1/configs/import/preview — same inputs as /import (multipart/form-data: file + resolutionPolicy), returns ImportConfigPreviewDto."
 

--- a/specs/007-config-import-preview/spec.md
+++ b/specs/007-config-import-preview/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `007-config-import-preview`
 **Created**: 2026-03-16
 **Status**: Draft
+**Capability**: export-import
 **Input**: User description: "Implement preview for config import. New endpoint POST /api/v1/configs/import/preview — same inputs as /import (multipart/form-data: file + resolutionPolicy), returns ImportConfigPreviewDto."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/008-read-only-role/spec.md
+++ b/specs/008-read-only-role/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `008-read-only-role`
 **Created**: 2026-03-18
 **Status**: Draft
+**Capability**: security
 **Input**: User description: "There is a need to provide read-only access to operations in deployment manager. GitHub issue with more details: https://github.com/epam/ai-dial-admin-deployment-manager-backend/issues/149. Example implementation: https://github.com/epam/ai-dial-admin-backend/pull/761. Implementation in ai-dial-admin-backend can be carried over to deployment manager, adding new annotations on non-read operations to controllers and modifying existing tests"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/008-read-only-role/spec.md
+++ b/specs/008-read-only-role/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `008-read-only-role`
 **Created**: 2026-03-18
-**Status**: Draft
+**Status**: Implemented
 **Capability**: security
 **Input**: User description: "There is a need to provide read-only access to operations in deployment manager. GitHub issue with more details: https://github.com/epam/ai-dial-admin-deployment-manager-backend/issues/149. Example implementation: https://github.com/epam/ai-dial-admin-backend/pull/761. Implementation in ai-dial-admin-backend can be carried over to deployment manager, adding new annotations on non-read operations to controllers and modifying existing tests"
 

--- a/specs/009-mcp-registry-filtering/spec.md
+++ b/specs/009-mcp-registry-filtering/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `009-mcp-registry-filtering`
 **Created**: 2026-03-18
-**Status**: Draft
+**Status**: Implemented
 **Capability**: mcp-registry
 **Input**: User description: "I want to adjust MCP registry functionality. Want to support filtering on BE for some properties. MCP registry itself doesn't support filters except for name. Hence I propose to filter it on BE runtime. Read up to N pages from MCP registry and try to collect one page or response collected result after N."
 

--- a/specs/009-mcp-registry-filtering/spec.md
+++ b/specs/009-mcp-registry-filtering/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `009-mcp-registry-filtering`
 **Created**: 2026-03-18
 **Status**: Draft
+**Capability**: mcp-registry
 **Input**: User description: "I want to adjust MCP registry functionality. Want to support filtering on BE for some properties. MCP registry itself doesn't support filters except for name. Hence I propose to filter it on BE runtime. Read up to N pages from MCP registry and try to collect one page or response collected result after N."
 
 ## Phased Approach

--- a/specs/010-import-validations/spec.md
+++ b/specs/010-import-validations/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `010-import-validations`
 **Created**: 2026-03-19
-**Status**: Draft
+**Status**: Implemented
 **Capability**: export-import
 **Input**: User description: "Config import does not validate deserialized entities. In DTOs there are annotations on fields, some of them are linked to custom validators. Import must validate deserialized entities (domain objects) similarly to how DTOs are validated. Do a research to find the best way to solve this issue."
 

--- a/specs/010-import-validations/spec.md
+++ b/specs/010-import-validations/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `010-import-validations`
 **Created**: 2026-03-19
 **Status**: Draft
+**Capability**: export-import
 **Input**: User description: "Config import does not validate deserialized entities. In DTOs there are annotations on fields, some of them are linked to custom validators. Import must validate deserialized entities (domain objects) similarly to how DTOs are validated. Do a research to find the best way to solve this issue."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/011-application-type/spec.md
+++ b/specs/011-application-type/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `011-application-type`
 **Created**: 2026-03-20
 **Status**: Draft
+**Capability**: application-image-definitions, application-deployments
 **Input**: User description: "Support new image definition and deployment type - Application. It should be identical to Adapter image definition and deployment (for now, can change in the future)"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/011-application-type/spec.md
+++ b/specs/011-application-type/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `011-application-type`
 **Created**: 2026-03-20
-**Status**: Draft
+**Status**: Implemented
 **Capability**: application-image-definitions, application-deployments
 **Input**: User description: "Support new image definition and deployment type - Application. It should be identical to Adapter image definition and deployment (for now, can change in the future)"
 

--- a/specs/012-nim-url-schema/spec.md
+++ b/specs/012-nim-url-schema/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `012-nim-url-schema`  
 **Created**: 2026-03-31  
 **Status**: Draft  
+**Capability**: nim-deployments  
 **Input**: User description: "NIM service contains URL without schema (http://, https://), but we need to return URL with schema. You need to modify URL extraction logic, so schema prefix would be added depending on what URL is used. If clusterEndpoint - add http, if externalEndpoint - add https. Ability to overwrite schema should be present."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/012-nim-url-schema/spec.md
+++ b/specs/012-nim-url-schema/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `012-nim-url-schema`  
 **Created**: 2026-03-31  
-**Status**: Draft  
+**Status**: Implemented  
 **Capability**: nim-deployments  
 **Input**: User description: "NIM service contains URL without schema (http://, https://), but we need to return URL with schema. You need to modify URL extraction logic, so schema prefix would be added depending on what URL is used. If clusterEndpoint - add http, if externalEndpoint - add https. Ability to overwrite schema should be present."
 

--- a/specs/013-nim-served-model-name/spec.md
+++ b/specs/013-nim-served-model-name/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `013-nim-served-model-name`  
 **Created**: 2026-04-08  
-**Status**: Draft  
+**Status**: Implemented  
 **Capability**: nim-deployments  
 **Input**: User description: "NIM containers serve models under a name derived from the image. Users want to override the model name exposed via the NIM API (/v1/models, /v1/chat/completions). NVIDIA NIM supports the NIM_SERVED_MODEL_NAME environment variable for this."
 

--- a/specs/013-nim-served-model-name/spec.md
+++ b/specs/013-nim-served-model-name/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `013-nim-served-model-name`  
 **Created**: 2026-04-08  
 **Status**: Draft  
+**Capability**: nim-deployments  
 **Input**: User description: "NIM containers serve models under a name derived from the image. Users want to override the model name exposed via the NIM API (/v1/models, /v1/chat/completions). NVIDIA NIM supports the NIM_SERVED_MODEL_NAME environment variable for this."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/014-auditing/spec.md
+++ b/specs/014-auditing/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `014-auditing`
 **Created**: 2026-04-14
 **Status**: Draft
+**Capability**: N/A — creates new capability auditing
 **Input**: User description: "Add auditing in ai-dial-admin-deployment-manager-backend based on ai-dial-admin-backend patterns. Use the same patterns, technologies and endpoints."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/014-auditing/spec.md
+++ b/specs/014-auditing/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `014-auditing`
 **Created**: 2026-04-14
-**Status**: Draft
+**Status**: Implemented
 **Capability**: N/A — creates new capability auditing
 **Input**: User description: "Add auditing in ai-dial-admin-deployment-manager-backend based on ai-dial-admin-backend patterns. Use the same patterns, technologies and endpoints."
 

--- a/specs/015-nim-kserve-migration/spec.md
+++ b/specs/015-nim-kserve-migration/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `019-nim-kserve-migration`  
 **Created**: 2026-04-20  
 **Status**: Implemented (kserve mode gated behind a feature flag, see 2026-04-24 revision below)
+**Capability**: nim-deployments, kubernetes-manifests
 **Input**: User description: Migrate NIM CRD generation from standalone inferencePlatform with nginx ingress to kserve inferencePlatform with Knative autoscaling, removing direct ingress management, and adding configurable PVC storage size per deployment.
 
 ## Revision 2026-04-24: kserve mode made opt-in

--- a/specs/015-nim-kserve-migration/spec.md
+++ b/specs/015-nim-kserve-migration/spec.md
@@ -1,8 +1,8 @@
 # Feature Specification: NIM KServe Migration & Configurable Storage Size
 
-**Feature Branch**: `019-nim-kserve-migration`  
+**Feature Branch**: `015-nim-kserve-migration`  
 **Created**: 2026-04-20  
-**Status**: Implemented (kserve mode gated behind a feature flag, see 2026-04-24 revision below)
+**Status**: Implemented
 **Capability**: nim-deployments, kubernetes-manifests
 **Input**: User description: Migrate NIM CRD generation from standalone inferencePlatform with nginx ingress to kserve inferencePlatform with Knative autoscaling, removing direct ingress management, and adding configurable PVC storage size per deployment.
 

--- a/specs/016-node-pool-selector/spec.md
+++ b/specs/016-node-pool-selector/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `016-node-pool-selector`  
 **Created**: 2026-04-21  
 **Status**: Draft  
+**Capability**: deployments  
 **Input**: User description: "Design an API for a node pool selector UI. Users select a single node pool for their deployment. A new API returns available node pools with live Kubernetes resource utilization. Deployment create/update/get endpoints are extended to carry the selected node pool."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/016-node-pool-selector/spec.md
+++ b/specs/016-node-pool-selector/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `016-node-pool-selector`  
 **Created**: 2026-04-21  
-**Status**: Draft  
+**Status**: Implemented  
 **Capability**: deployments  
 **Input**: User description: "Design an API for a node pool selector UI. Users select a single node pool for their deployment. A new API returns available node pools with live Kubernetes resource utilization. Deployment create/update/get endpoints are extended to carry the selected node pool."
 

--- a/specs/017-stop-image-build/spec.md
+++ b/specs/017-stop-image-build/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `017-stop-image-build`  
 **Created**: 2026-04-20  
-**Status**: Draft  
+**Status**: Implemented  
 **Capability**: image-builds  
 **Input**: User description: "Currently, there is no ability to interrupt image build process - this feature should be implemented."
 

--- a/specs/017-stop-image-build/spec.md
+++ b/specs/017-stop-image-build/spec.md
@@ -3,6 +3,7 @@
 **Feature Branch**: `017-stop-image-build`  
 **Created**: 2026-04-20  
 **Status**: Draft  
+**Capability**: image-builds  
 **Input**: User description: "Currently, there is no ability to interrupt image build process - this feature should be implemented."
 
 ## Clarifications

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,7 +28,7 @@ Numbered specs created via `/speckit.specify`. `Status` reflects the value in ea
 | [012-nim-url-schema](012-nim-url-schema/spec.md) | Implemented | nim-deployments | Add `http`/`https` schema prefix to NIM service URLs based on endpoint kind |
 | [013-nim-served-model-name](013-nim-served-model-name/spec.md) | Implemented | nim-deployments | Override served model name via `NIM_SERVED_MODEL_NAME` env var |
 | [014-auditing](014-auditing/spec.md) | Implemented | _new capability_ `auditing` | Activity history for deployment resources via Hibernate Envers |
-| [015-nim-kserve-migration](015-nim-kserve-migration/spec.md) | Implemented (gated) | nim-deployments, kubernetes-manifests | Migrate NIM CRD generation to KServe `inferencePlatform` (opt-in via env flag) |
+| [015-nim-kserve-migration](015-nim-kserve-migration/spec.md) | Implemented | nim-deployments, kubernetes-manifests | Migrate NIM CRD generation to KServe `inferencePlatform` (opt-in via env flag) |
 | [016-node-pool-selector](016-node-pool-selector/spec.md) | Implemented | deployments | Node-pool selector API + per-deployment node pool assignment |
 | [017-stop-image-build](017-stop-image-build/spec.md) | Implemented | image-builds | Stop in-flight image builds from the UI/API |
 
@@ -76,6 +76,7 @@ Numbered specs created via `/speckit.specify`. `Status` reflects the value in ea
 | [security](security/spec.md) | Implemented | Configurable security modes (none / basic / oidc), JWT/OIDC multi-provider authentication (Azure, Keycloak, Auth0, Okta, Cognito), Azure Identity SDK |
 | [api-conventions](api-conventions/spec.md) | Implemented | REST API contract — versioning, ErrorView response structure with distributed tracing (traceparent), pagination patterns |
 | [observability-and-logging](observability-and-logging/spec.md) | Implemented | OpenTelemetry log integration, W3C Trace Context propagation, `@LogExecution` AOP convention |
+| [auditing](auditing/spec.md) | Implemented | Hibernate Envers change-tracking + denormalized activity feed; activity / revision / per-entity snapshot endpoints |
 
 ## Infrastructure
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -16,7 +16,7 @@ Numbered specs created via `/speckit.specify`. `Status` reflects the value in ea
 |---|---|---|---|
 | [001-deployment-topics](001-deployment-topics/spec.md) | Implemented | topics | Add topic assignment on deployments, mirroring image-definition topics |
 | [002-deployment-command-args](002-deployment-command-args/spec.md) | Implemented | deployments | Support `command` and `args` configuration for all deployment types |
-| [003-unified-deployment-source](003-unified-deployment-source/spec.md) | Draft | deployments | Unified deployment source model with direct `imageReference` for Knative |
+| [003-unified-deployment-source](003-unified-deployment-source/spec.md) | Implemented | deployments | Unified deployment source model with direct `imageReference` for Knative |
 | [004-store-service-name](004-store-service-name/spec.md) | Implemented | deployments | Persist resolved K8s service name on deployment row to survive prefix changes |
 | [005-external-registry-ref](005-external-registry-ref/spec.md) | Implemented | image-definitions | External registry reference on image/deployment sources for client lookups |
 | [006-config-export-preview](006-config-export-preview/spec.md) | Implemented | export-import | `POST` preview endpoint that previews export contents without producing the ZIP |
@@ -30,7 +30,7 @@ Numbered specs created via `/speckit.specify`. `Status` reflects the value in ea
 | [014-auditing](014-auditing/spec.md) | Implemented | _new capability_ `auditing` | Activity history for deployment resources via Hibernate Envers |
 | [015-nim-kserve-migration](015-nim-kserve-migration/spec.md) | Implemented (gated) | nim-deployments, kubernetes-manifests | Migrate NIM CRD generation to KServe `inferencePlatform` (opt-in via env flag) |
 | [016-node-pool-selector](016-node-pool-selector/spec.md) | Implemented | deployments | Node-pool selector API + per-deployment node pool assignment |
-| [017-stop-image-build](017-stop-image-build/spec.md) | Partially implemented | image-builds | Stop in-flight image builds from the UI/API — core ships; tests T024–T026, T032–T033 outstanding |
+| [017-stop-image-build](017-stop-image-build/spec.md) | Implemented | image-builds | Stop in-flight image builds from the UI/API |
 
 ---
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,6 +4,34 @@ This directory contains one spec file per capability implemented in the AI DIAL 
 
 **Workflow:** New features follow the spec-kit workflow: `/speckit.specify` (create spec) → `/speckit.plan` → `/speckit.tasks` → `/speckit.implement`. Use `/speckit.constitution` to amend project-wide conventions.
 
+Numbered feature specs (`NNN-<short-name>/`) declare a `**Capability**:` field that maps them to the capability specs below; on implementation, the matching capability spec is updated and gains an `Implemented via NNN-<feature>` reference. See root `CLAUDE.md` § "Numbered-spec hygiene" and `.specify/memory/constitution.md` § "spec-kit Workflow Rules".
+
+---
+
+## In-flight & recent features
+
+Numbered specs created via `/speckit.specify`. `Status` reflects the value in each spec's header — flip to `Implemented` only when the feature ships and the matching capability spec(s) are updated.
+
+| Feature | Status | Capability | Brief |
+|---|---|---|---|
+| [001-deployment-topics](001-deployment-topics/spec.md) | Draft | topics | Add topic assignment on deployments, mirroring image-definition topics |
+| [002-deployment-command-args](002-deployment-command-args/spec.md) | Draft | deployments | Support `command` and `args` configuration for all deployment types |
+| [003-unified-deployment-source](003-unified-deployment-source/spec.md) | Draft | deployments | Unified deployment source model with direct `imageReference` for Knative |
+| [004-store-service-name](004-store-service-name/spec.md) | Implemented | deployments | Persist resolved K8s service name on deployment row to survive prefix changes |
+| [005-external-registry-ref](005-external-registry-ref/spec.md) | Draft | image-definitions | External registry reference on image/deployment sources for client lookups |
+| [006-config-export-preview](006-config-export-preview/spec.md) | Draft | export-import | `POST` preview endpoint that previews export contents without producing the ZIP |
+| [007-config-import-preview](007-config-import-preview/spec.md) | Draft | export-import | Preview import outcome (creates / overwrites / skips) before committing |
+| [008-read-only-role](008-read-only-role/spec.md) | Draft | security | Read-only admin role; non-read endpoints carry write annotations |
+| [009-mcp-registry-filtering](009-mcp-registry-filtering/spec.md) | Draft | mcp-registry | Backend filtering of MCP registry beyond what the upstream registry supports |
+| [010-import-validations](010-import-validations/spec.md) | Draft | export-import | Validate deserialized domain objects on import with the same rules as DTOs |
+| [011-application-type](011-application-type/spec.md) | Draft | application-image-definitions, application-deployments | New `Application` image-definition + deployment subtype |
+| [012-nim-url-schema](012-nim-url-schema/spec.md) | Draft | nim-deployments | Add `http`/`https` schema prefix to NIM service URLs based on endpoint kind |
+| [013-nim-served-model-name](013-nim-served-model-name/spec.md) | Draft | nim-deployments | Override served model name via `NIM_SERVED_MODEL_NAME` env var |
+| [014-auditing](014-auditing/spec.md) | Draft | _new capability_ `auditing` | Activity history for deployment resources via Hibernate Envers |
+| [015-nim-kserve-migration](015-nim-kserve-migration/spec.md) | Implemented (gated) | nim-deployments, kubernetes-manifests | Migrate NIM CRD generation to KServe `inferencePlatform` (opt-in via env flag) |
+| [016-node-pool-selector](016-node-pool-selector/spec.md) | Draft | deployments | Node-pool selector API + per-deployment node pool assignment |
+| [017-stop-image-build](017-stop-image-build/spec.md) | Draft | image-builds | Stop in-flight image builds from the UI/API |
+
 ---
 
 ## Core Domain

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,23 +14,23 @@ Numbered specs created via `/speckit.specify`. `Status` reflects the value in ea
 
 | Feature | Status | Capability | Brief |
 |---|---|---|---|
-| [001-deployment-topics](001-deployment-topics/spec.md) | Draft | topics | Add topic assignment on deployments, mirroring image-definition topics |
-| [002-deployment-command-args](002-deployment-command-args/spec.md) | Draft | deployments | Support `command` and `args` configuration for all deployment types |
+| [001-deployment-topics](001-deployment-topics/spec.md) | Implemented | topics | Add topic assignment on deployments, mirroring image-definition topics |
+| [002-deployment-command-args](002-deployment-command-args/spec.md) | Implemented | deployments | Support `command` and `args` configuration for all deployment types |
 | [003-unified-deployment-source](003-unified-deployment-source/spec.md) | Draft | deployments | Unified deployment source model with direct `imageReference` for Knative |
 | [004-store-service-name](004-store-service-name/spec.md) | Implemented | deployments | Persist resolved K8s service name on deployment row to survive prefix changes |
-| [005-external-registry-ref](005-external-registry-ref/spec.md) | Draft | image-definitions | External registry reference on image/deployment sources for client lookups |
-| [006-config-export-preview](006-config-export-preview/spec.md) | Draft | export-import | `POST` preview endpoint that previews export contents without producing the ZIP |
-| [007-config-import-preview](007-config-import-preview/spec.md) | Draft | export-import | Preview import outcome (creates / overwrites / skips) before committing |
-| [008-read-only-role](008-read-only-role/spec.md) | Draft | security | Read-only admin role; non-read endpoints carry write annotations |
-| [009-mcp-registry-filtering](009-mcp-registry-filtering/spec.md) | Draft | mcp-registry | Backend filtering of MCP registry beyond what the upstream registry supports |
-| [010-import-validations](010-import-validations/spec.md) | Draft | export-import | Validate deserialized domain objects on import with the same rules as DTOs |
-| [011-application-type](011-application-type/spec.md) | Draft | application-image-definitions, application-deployments | New `Application` image-definition + deployment subtype |
-| [012-nim-url-schema](012-nim-url-schema/spec.md) | Draft | nim-deployments | Add `http`/`https` schema prefix to NIM service URLs based on endpoint kind |
-| [013-nim-served-model-name](013-nim-served-model-name/spec.md) | Draft | nim-deployments | Override served model name via `NIM_SERVED_MODEL_NAME` env var |
-| [014-auditing](014-auditing/spec.md) | Draft | _new capability_ `auditing` | Activity history for deployment resources via Hibernate Envers |
+| [005-external-registry-ref](005-external-registry-ref/spec.md) | Implemented | image-definitions | External registry reference on image/deployment sources for client lookups |
+| [006-config-export-preview](006-config-export-preview/spec.md) | Implemented | export-import | `POST` preview endpoint that previews export contents without producing the ZIP |
+| [007-config-import-preview](007-config-import-preview/spec.md) | Implemented | export-import | Preview import outcome (creates / overwrites / skips) before committing |
+| [008-read-only-role](008-read-only-role/spec.md) | Implemented | security | Read-only admin role; non-read endpoints carry write annotations |
+| [009-mcp-registry-filtering](009-mcp-registry-filtering/spec.md) | Implemented | mcp-registry | Backend filtering of MCP registry beyond what the upstream registry supports |
+| [010-import-validations](010-import-validations/spec.md) | Implemented | export-import | Validate deserialized domain objects on import with the same rules as DTOs |
+| [011-application-type](011-application-type/spec.md) | Implemented | application-image-definitions, application-deployments | New `Application` image-definition + deployment subtype |
+| [012-nim-url-schema](012-nim-url-schema/spec.md) | Implemented | nim-deployments | Add `http`/`https` schema prefix to NIM service URLs based on endpoint kind |
+| [013-nim-served-model-name](013-nim-served-model-name/spec.md) | Implemented | nim-deployments | Override served model name via `NIM_SERVED_MODEL_NAME` env var |
+| [014-auditing](014-auditing/spec.md) | Implemented | _new capability_ `auditing` | Activity history for deployment resources via Hibernate Envers |
 | [015-nim-kserve-migration](015-nim-kserve-migration/spec.md) | Implemented (gated) | nim-deployments, kubernetes-manifests | Migrate NIM CRD generation to KServe `inferencePlatform` (opt-in via env flag) |
-| [016-node-pool-selector](016-node-pool-selector/spec.md) | Draft | deployments | Node-pool selector API + per-deployment node pool assignment |
-| [017-stop-image-build](017-stop-image-build/spec.md) | Draft | image-builds | Stop in-flight image builds from the UI/API |
+| [016-node-pool-selector](016-node-pool-selector/spec.md) | Implemented | deployments | Node-pool selector API + per-deployment node pool assignment |
+| [017-stop-image-build](017-stop-image-build/spec.md) | Partially implemented | image-builds | Stop in-flight image builds from the UI/API — core ships; tests T024–T026, T032–T033 outstanding |
 
 ---
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -27,7 +27,7 @@ Numbered specs created via `/speckit.specify`. `Status` reflects the value in ea
 | [011-application-type](011-application-type/spec.md) | Implemented | application-image-definitions, application-deployments | New `Application` image-definition + deployment subtype |
 | [012-nim-url-schema](012-nim-url-schema/spec.md) | Implemented | nim-deployments | Add `http`/`https` schema prefix to NIM service URLs based on endpoint kind |
 | [013-nim-served-model-name](013-nim-served-model-name/spec.md) | Implemented | nim-deployments | Override served model name via `NIM_SERVED_MODEL_NAME` env var |
-| [014-auditing](014-auditing/spec.md) | Implemented | _new capability_ `auditing` | Activity history for deployment resources via Hibernate Envers |
+| [014-auditing](014-auditing/spec.md) | Implemented | N/A — creates new capability auditing | Activity history for deployment resources via Hibernate Envers |
 | [015-nim-kserve-migration](015-nim-kserve-migration/spec.md) | Implemented | nim-deployments, kubernetes-manifests | Migrate NIM CRD generation to KServe `inferencePlatform` (opt-in via env flag) |
 | [016-node-pool-selector](016-node-pool-selector/spec.md) | Implemented | deployments | Node-pool selector API + per-deployment node pool assignment |
 | [017-stop-image-build](017-stop-image-build/spec.md) | Implemented | image-builds | Stop in-flight image builds from the UI/API |

--- a/specs/auditing/spec.md
+++ b/specs/auditing/spec.md
@@ -1,0 +1,141 @@
+# Auditing
+
+## Purpose
+This spec describes the change-tracking and activity-feed capability — Hibernate Envers preserves the full historical state of audited entities, and a denormalized activity feed exposes who-changed-what queries to administrators. Implemented via 014-auditing.
+
+Status: **Implemented**
+
+## Key Terms
+- **Activity**: A single tracked change event (Create / Update / Delete) on an audited resource — captures activity type, resource type, resource identifier, author name, author email, and timestamp. Linked to a revision.
+- **Revision**: A grouping of all changes within a single transaction — sequential id, transaction timestamp, initiating author identity. One revision → many activities.
+- **Audit Snapshot**: A historical copy of an entity's complete state at the time of a change, persisted to Envers `_AUD` tables and retrieved via `AuditReader`.
+- **Activity feed**: The denormalized, query-optimized table that powers `/api/v1/activities`; complements raw Envers history.
+
+## Audited resource types
+`AdapterDeployment`, `ApplicationDeployment`, `InterceptorDeployment`, `McpDeployment`, `NimDeployment`, `InferenceDeployment`, `AdapterImageDefinition`, `ApplicationImageDefinition`, `InterceptorImageDefinition`, `McpImageDefinition`, and `DomainWhitelist`.
+
+`DisposableResource` and `ComponentRemoval` are excluded as internal housekeeping. Base types (`Deployment`, `ImageDefinition`) are audited at the database level via Envers but are not exposed as activity resource types — entities are persisted as concrete subtypes only.
+
+## Requirements
+
+### Requirement: All CUD operations on audited entities produce an activity record
+The system SHALL track every insert, update, and delete on audited entities, preserving full entity state at each change point and recording a corresponding activity entry.
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+#### Scenario: Create activity recorded
+- **WHEN** an administrator creates a new deployment
+- **THEN** a `Create` activity for that deployment appears in the activity feed with the correct author, timestamp, and resource identifier
+
+#### Scenario: Update activity recorded
+- **WHEN** an administrator updates a deployment's configuration
+- **THEN** an `Update` activity reflecting the change appears in the activity feed
+
+#### Scenario: Delete activity recorded
+- **WHEN** an administrator deletes a deployment
+- **THEN** a `Delete` activity for that deployment appears in the activity feed
+
+#### Scenario: No activity on rollback
+- **WHEN** a transaction modifying audited entities rolls back
+- **THEN** no audit records are persisted (audit records are part of the same transaction)
+
+### Requirement: Author identity captured from security context
+The system SHALL extract the username and email of the user who initiated each change from the authenticated security context. Unauthenticated HTTP requests record `"unknown"`; non-HTTP contexts (informer callbacks, scheduled tasks, build pipeline) record `"system"`.
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+#### Scenario: Authenticated user attribution
+- **WHEN** an authenticated administrator modifies an audited resource
+- **THEN** the activity records the administrator's username and email
+
+#### Scenario: Internal API attribution
+- **WHEN** an internal HTTP request without auth modifies an audited resource
+- **THEN** the activity records `"unknown"` as author
+
+#### Scenario: Background task attribution
+- **WHEN** a K8s informer callback or scheduled task modifies an audited resource
+- **THEN** the activity records `"system"` as author
+
+### Requirement: Transaction-consistent timestamp and revision
+The system SHALL assign a single timestamp and revision id to all audit records produced within one transaction so they can be correlated.
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+#### Scenario: Batch update shares revision
+- **WHEN** multiple audited entities are modified within a single transaction
+- **THEN** all resulting activity entries and audit snapshots share the same revision id and timestamp
+
+### Requirement: Activity deduplication within a transaction
+When the same resource is affected multiple times within a single transaction, the system SHALL retain a single activity entry for that resource — `Create` or `Delete` takes precedence over `Update`.
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+#### Scenario: Multiple updates collapse
+- **WHEN** the same resource is updated twice within a single transaction
+- **THEN** a single `Update` activity entry exists for that resource
+
+#### Scenario: Create + update collapse to create
+- **WHEN** a resource is created and then updated within a single transaction
+- **THEN** only the `Create` activity is retained for that resource
+
+### Requirement: Activity list and detail endpoints
+The system SHALL expose `POST /api/v1/activities` for filtered listing with pagination and `GET /api/v1/activities/{activityId}` for single-record retrieval. Filters are `{column, operator, value}` tuples supporting `eq`, `ne`, `lt`, `le`, `gt`, `ge`, `co`, `nc`. Filterable columns: activity id, activity type, resource type, resource identifier, author name, author email, transaction timestamp.
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+#### Scenario: Filter by resource type
+- **WHEN** an administrator filters by resource type `McpDeployment`
+- **THEN** only activities for `McpDeployment` are returned
+
+#### Scenario: Filter by activity type
+- **WHEN** an administrator filters by activity type `Delete`
+- **THEN** only delete activities are returned
+
+#### Scenario: Activity not found
+- **WHEN** the administrator requests an activity by an unknown identifier
+- **THEN** the system returns HTTP 404 with an `ErrorView` body
+
+### Requirement: Revision list and lookup endpoints
+The system SHALL expose `POST /api/v1/history/revisions` for filtered listing with pagination and `POST /api/v1/history/revisions/query` for single-revision lookup by id or by timestamp (most recent at or before).
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+#### Scenario: Revision query by timestamp
+- **WHEN** the administrator queries by timestamp `T2` (where revisions exist at `T1 < T2 < T3`)
+- **THEN** the revision at `T1` is returned (most recent at or before)
+
+#### Scenario: Revision query no match
+- **WHEN** no revision exists at or before the given timestamp
+- **THEN** the system returns HTTP 404
+
+### Requirement: Per-controller entity snapshot endpoints
+Each audited entity controller SHALL expose `GET /{id}/revision/{revision}` returning the entity DTO at the specified revision, and `GET /revision/{revision}` returning all entities of that type at the specified revision. Snapshot DTOs are the same shape as the current-state DTOs (no separate `EntityRevisionDto` wrapper — rollback is out of scope).
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+#### Scenario: Snapshot at past revision
+- **WHEN** a deployment exists at revisions `R1` and `R2` and the administrator requests its snapshot at `R1`
+- **THEN** the original state is returned
+
+#### Scenario: Snapshot before creation
+- **WHEN** an entity was created at revision `R1` and the administrator requests its snapshot at a revision before `R1`
+- **THEN** the system returns HTTP 404
+
+#### Scenario: Deleted entity in collection snapshot
+- **WHEN** an image definition was deleted at revision `R2` and the administrator requests all image definitions at revision `R1`
+- **THEN** the deleted image definition is included in the result
+
+### Requirement: Multi-vendor migration support
+Audit schema changes SHALL be managed through versioned Flyway migrations compatible with H2, PostgreSQL, and SQL Server.
+
+Status: **Implemented** (Implemented via 014-auditing)
+
+## Implementation Notes
+- ORM-level audit: Hibernate Envers via `@Audited` on entities; `_AUD` tables managed by Flyway migrations under `src/main/resources/db/migration/{H2,POSTGRES,MS_SQL_SERVER}/`.
+- Author capture: `dao/audit/listener/` revision listener writes username/email/timestamp into the revision row, sourced from the Spring Security context for HTTP requests and falling back to `"unknown"` / `"system"` per the rules above.
+- Activity feed: denormalized `Activity` table populated transactionally; dedup logic (`Create`/`Delete` over `Update`) is applied per revision.
+- Snapshot retrieval: Hibernate Envers `AuditReader` API; respects JOINED inheritance so querying `DeploymentEntity` at a revision returns the concrete subtype.
+- Service layer: `service/audit/AuditActivityService.java` (activity feed queries), `service/audit/HistoryService.java` (revision and entity-snapshot queries).
+- Controllers: `web/controller/AuditActivityController.java` (`/api/v1/activities`), `web/controller/HistoryController.java` (`/api/v1/history`); per-resource snapshot endpoints live on each entity's existing controller.
+- Authorization: activity / history endpoints are accessible to all authenticated users (no `@FullAdminOnly` restriction).
+- Related specs: `deployments`, `mcp-deployments`, `interceptor-deployments`, `adapter-deployments`, `application-deployments`, `inference-deployments`, `nim-deployments`, `image-definitions`, `mcp-image-definitions`, `interceptor-image-definitions`, `adapter-image-definitions`, `application-image-definitions`, `domain-whitelist`, `security`, `api-conventions`.

--- a/src/main/java/com/epam/aidial/deployment/manager/configuration/CLAUDE.md
+++ b/src/main/java/com/epam/aidial/deployment/manager/configuration/CLAUDE.md
@@ -1,0 +1,36 @@
+# Configuration package
+
+Spring `@Configuration` classes and `@ConfigurationProperties` value objects — datasource wiring, security, telemetry, HTTP clients, Kubernetes config, executors, retries. See `.specify/memory/constitution.md` for the full architecture; this file lists only what's specific to this package.
+
+## Critical rule: defaults live only in `application.yml`
+
+`@ConfigurationProperties` fields MUST be declared **without** Java initializers. Defaults are expressed once in `application.yml` via `${ENV_VAR:default}` syntax. See constitution § "Configuration property defaults".
+
+```java
+// CORRECT
+private int maxRetries;
+
+// WRONG — duplicates the YAML default; risks divergence
+private int maxRetries = 3;
+```
+
+When you add a new env-var-backed property here:
+- Declare the field with no initializer.
+- Add the matching key to `application.yml` with `${ENV_VAR:default}`.
+- Update `docs/configuration.md` (manually maintained — see constitution § "Configuration documentation").
+
+## Subpackages
+
+| Path | Responsibility |
+|---|---|
+| `datasource/` | Multi-vendor `DataSource` wiring; selects H2 / Postgres / SQL Server via `DATASOURCE_VENDOR` |
+| `encryption/` | Symmetric encryption setup for sensitive env-var storage |
+| `export/` | Configuration import/export wiring (used by `service/config/`) |
+| `kubernetes/` | Fabric8 client configuration, informer wiring |
+| `logging/` | `@LogExecution` AOP wiring (`CustomizableTraceInterceptor`) |
+
+Top-level files are individual `@Configuration` / `*Properties` classes — one concern each.
+
+## Related specs
+
+- `specs/api-conventions/spec.md`, `specs/security/spec.md`, `specs/observability-and-logging/spec.md` for cross-cutting concerns wired here.

--- a/src/main/java/com/epam/aidial/deployment/manager/dao/CLAUDE.md
+++ b/src/main/java/com/epam/aidial/deployment/manager/dao/CLAUDE.md
@@ -1,0 +1,35 @@
+# DAO layer
+
+JPA entities, Spring Data repositories, custom repository wrappers, persistence mappers, audit. See `.specify/memory/constitution.md` for the full architecture; this file lists only what's specific to this layer.
+
+## Layer rules
+
+- Called by `service/` only. MUST NOT call `service/` or `kubernetes/`.
+- `@Transactional` is permitted here on repository wrapper methods where the data-access boundary is inherent.
+- `@LogExecution` MUST be on every `@Repository` / `@Component`.
+
+## Naming
+
+- Entities: `*Entity` in `dao/entity/`. Pure data holders — no business logic, no service calls, no Lombok `@Builder` defaults that have side effects.
+- Spring Data interfaces: `*JpaRepository` in `dao/jpa/`.
+- Custom domain-mapping wrappers: `*Repository` in `dao/repository/`. These are the surface the service layer talks to.
+- Persistence mappers: `Persistence*Mapper` in `dao/mapper/`. MapStruct `componentModel = "spring"`.
+
+## Subpackages
+
+| Path | Responsibility |
+|---|---|
+| `entity/` | JPA entity classes (`*Entity`) — pure data holders |
+| `jpa/` | Spring Data interfaces (`*JpaRepository`) — direct JPA surface |
+| `repository/` | Custom domain-mapping wrappers (`*Repository`) — what the service layer talks to |
+| `mapper/` | MapStruct persistence mappers (`Persistence*Mapper`) — entity ↔ domain |
+| `audit/` | Hibernate Envers audit revision listeners and queries |
+
+## Schema invariants
+
+- JPA `ddl-auto: validate`. Flyway owns the schema — entities MUST NOT drive table creation or alteration.
+- Adding a column / table is a Flyway migration first, entity change second.
+
+## Related specs
+
+- `specs/database-and-migrations/spec.md` — vendor strategy, migration paths, naming.

--- a/src/main/java/com/epam/aidial/deployment/manager/kubernetes/CLAUDE.md
+++ b/src/main/java/com/epam/aidial/deployment/manager/kubernetes/CLAUDE.md
@@ -1,0 +1,28 @@
+# Kubernetes layer
+
+The only place in the codebase that may import Fabric8 / `io.kubernetes` API types in non-configuration code (constitution Principle III). See `.specify/memory/constitution.md` for the full architecture; this file lists only what's specific to this layer.
+
+## Layer rules
+
+- Called by `service/` only. MUST NOT be called from `web/` or `dao/`.
+- `@LogExecution` MUST be on every `@Component`.
+- Polling loops for K8s state are forbidden — use Fabric8 informers (`kubernetes/informer/`).
+
+## Subpackages
+
+| Path | Responsibility |
+|---|---|
+| `event/` | Watch / stream K8s events to clients (SSE-backed in `service/`) |
+| `informer/` | Fabric8 informer registration + handlers; the canonical state-watching mechanism |
+| `knative/` | Knative Serving client, manifest generation for serverless workloads |
+| `kserve/` | KServe client and manifest generation for inference deployments |
+| `nim/` | NVIDIA NIM CRD (`NIMService`) client |
+
+Top-level utilities (`AbstractK8sResourceClient`, `K8sClient`, `JobRunner`, `PodLogReader`, etc.) are shared across subpackages.
+
+## Related specs
+
+- `specs/kubernetes-events/spec.md`
+- `specs/kubernetes-manifests/spec.md`
+- `specs/kubernetes-cleanup/spec.md`
+- `specs/inference-deployments/spec.md`, `specs/nim-deployments/spec.md` for KServe / NIM specifics.

--- a/src/main/java/com/epam/aidial/deployment/manager/service/CLAUDE.md
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/CLAUDE.md
@@ -1,0 +1,36 @@
+# Service layer
+
+Business logic, transaction boundaries, pipelines, caching, scheduled jobs. See `.specify/memory/constitution.md` for the full architecture; this file lists only what's specific to this layer.
+
+## Layer rules
+
+- May call `dao/` and `kubernetes/`. MUST NOT be called *from* `dao/` or `kubernetes/`.
+- `@Transactional` lives here (and on repository wrappers in `dao/`); not on controllers.
+- `@LogExecution` MUST be on every `@Service` / `@Component`.
+- Fabric8 / `io.kubernetes` types are forbidden in this layer — go through `kubernetes/` package abstractions (constitution Principle III).
+- `catch (Exception e)` is forbidden here; catch specific types. Top-level `Exception` catch is allowed only in `web/handler/DefaultExceptionHandler`.
+
+## Patterns
+
+- Service-level mappers (not DTO, not persistence) live under `mapper/` at the project root, named `*Mapper`. Don't put them in `web/mapper/` or `dao/mapper/`.
+- Cached lookups: Caffeine + `@Cacheable` / `@CacheEvict`.
+- Scheduled jobs that must run only once across replicas: ShedLock `@SchedulerLock`.
+- Image build pipeline: chain of steps under `service/pipeline/step/`. Add a new step by extending the chain rather than mutating existing steps.
+
+## Subpackages
+
+| Path | Responsibility |
+|---|---|
+| `audit/` | Audit activity recording, history queries (Hibernate Envers integration) |
+| `config/` | Configuration import/export orchestration (ZIP archive build/parse, conflict resolution) |
+| `deployment/` | Deployment lifecycle services — base, mcp, interceptor, adapter, application, inference, nim |
+| `manifest/` | KNative / KServe / NIM manifest generation; env var injection; probe converters |
+| `nodepool/` | Node-pool selector resolution for K8s scheduling |
+| `pipeline/` | Image build pipeline — multi-step chain in `pipeline/step/`, specifications in `pipeline/specification/` |
+| `security/` | Security mode resolution, JWT provider selection (azure / keycloak / auth0 / okta / cognito) |
+
+Top-level files in `service/` are utilities and single-purpose services that don't fit a subpackage cluster (e.g. `SseEmitterFactory`, `JobSpecification`, `McpClientFactory`).
+
+## Related specs
+
+- `specs/<capability>/spec.md` for the capability you're touching (e.g. `deployments`, `image-builds`, `mcp-servers`, `inference-deployments`).

--- a/src/main/java/com/epam/aidial/deployment/manager/web/CLAUDE.md
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/CLAUDE.md
@@ -6,7 +6,7 @@ REST controllers, DTOs, MapStruct DTO mappers, exception handlers, security filt
 
 - May call `service/`. MUST NOT call `dao/` or `kubernetes/` directly.
 - `@Transactional` is forbidden here (constitution Principle II).
-- `@LogExecution` MUST be on every `@RestController` / `@Controller` / `@Component`.
+- `@LogExecution` MUST be on every `@RestController` / `@Component`.
 
 ## Naming
 

--- a/src/main/java/com/epam/aidial/deployment/manager/web/CLAUDE.md
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/CLAUDE.md
@@ -1,0 +1,39 @@
+# Web layer
+
+REST controllers, DTOs, MapStruct DTO mappers, exception handlers, security filters, validation. See `.specify/memory/constitution.md` for the full architecture; this file lists only what's specific to this layer.
+
+## Layer rules
+
+- May call `service/`. MUST NOT call `dao/` or `kubernetes/` directly.
+- `@Transactional` is forbidden here (constitution Principle II).
+- `@LogExecution` MUST be on every `@RestController` / `@Controller` / `@Component`.
+
+## Naming
+
+- Request/response: `*Dto`, `*RequestDto`. Simple immutable shapes prefer Java `record` or Lombok `@Value`.
+- DTO mappers: `*DtoMapper` in `web/mapper/`. MapStruct `componentModel = "spring"`. Add `subclassExhaustiveStrategy = SubclassExhaustiveStrategy.RUNTIME_EXCEPTION` only for polymorphic mappers.
+
+## Subpackages
+
+| Path | Responsibility |
+|---|---|
+| `controller/` | `@RestController` classes; one per top-level resource. Internal endpoints live in `controller/internal/` |
+| `dto/` | Request/response shapes (`*Dto`, `*RequestDto`, records, `@Value`) |
+| `mapper/` | MapStruct DTO mappers (`*DtoMapper`) — domain → DTO and back |
+| `handler/` | `DefaultExceptionHandler`, `SseEmitter`-based streaming handlers |
+| `security/` | OAuth2 / JWT filter chain, role mapping, `SecurityInfoController` plumbing |
+| `validation/` | Custom Bean Validation constraints and validators |
+| `utils/` | Web-only helpers (header parsing, pagination conversion, etc.) |
+
+## API conventions
+
+- Public base path: `/api/v1/`. Internal: `/api/internal/v1/`.
+- Every endpoint method MUST have SpringDoc `@Operation(summary = "...")` and the relevant `@ApiResponse` annotations.
+- List endpoints that may return large datasets MUST accept `Pageable`.
+- Real-time streaming uses `SseEmitter` — see existing handlers in `web/handler/`.
+- Errors flow through `DefaultExceptionHandler` and serialize as `ErrorView` (`message`, `status`, `traceparent`, plus `path`, `method`, `error`).
+
+## Related specs
+
+- `specs/api-conventions/spec.md` — versioning, error schema, pagination.
+- Per-capability specs in `specs/<capability>/spec.md` — domain endpoints.

--- a/src/main/java/db/migration/CLAUDE.md
+++ b/src/main/java/db/migration/CLAUDE.md
@@ -1,0 +1,20 @@
+# Java migrations
+
+Flyway Java callbacks for migrations that need Java logic — e.g. parsing or transforming JSON columns where pure SQL is awkward. Spec: `specs/database-and-migrations/spec.md`.
+
+## Naming
+
+- `V{major}_{minor}__{Description}.java` — **underscore** separator (Java class names cannot contain `.`). Both `V1_25__Foo.java` and a hypothetical `V1.25__Foo.sql` resolve to the same logical Flyway version.
+
+## Subdirectories
+
+| Path | Applies to |
+|---|---|
+| `H2/` | H2 only |
+| `POSTGRES/` | PostgreSQL only |
+| `MS_SQL_SERVER/` | SQL Server only |
+| `common/` | All vendors — used when the same Java logic works against every supported DB |
+
+## When to choose Java over SQL
+
+Default to SQL (`src/main/resources/db/migration/`). Reach for Java only when the migration involves reading existing data, deserializing it, transforming, and writing it back — and SQL alone can't express the transformation cleanly.

--- a/src/main/resources/db/migration/CLAUDE.md
+++ b/src/main/resources/db/migration/CLAUDE.md
@@ -1,0 +1,21 @@
+# SQL migrations
+
+Flyway-managed schema and data migrations, one directory per supported database vendor. Spec: `specs/database-and-migrations/spec.md`. Constitution: `.specify/memory/constitution.md` § Multi-Vendor Database Pattern.
+
+## Naming
+
+- `V{major}.{minor}__{Description}.sql` — dot separator (standard Flyway). Example: `V1.59__AddSomeColumn.sql`.
+
+## Vendor parity
+
+Three subdirectories: `H2/`, `POSTGRES/`, `MS_SQL_SERVER/`. New migrations MUST be added to **all three** unless the change is intentionally vendor-specific (in which case state why in the file or commit message). Mismatched versions across vendors will cause Flyway baseline drift.
+
+## After editing
+
+- The PostToolUse hook (`.claude/hooks/generate-db-schema.sh`) regenerates `docs/db-schema.md` automatically when migration files change.
+- For non-Claude workflows, run `./gradlew generateDbSchema` and commit the updated `docs/db-schema.md`.
+- `docs/db-schema.md` is auto-generated; do not edit it by hand.
+
+## Java vs SQL migrations
+
+Use SQL for schema DDL and simple data shifts. For migrations needing Java logic (e.g. JSON transforms), use the Java migration tree at `src/main/java/db/migration/` instead — see the CLAUDE.md there.


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- related to #154 

### Description of changes

  - Constitution bumped to v1.4.0: reframed Tech Stack to defer to build.gradle for versions, added inline enforcement tags on every rule, softened operator-policy MUSTs, expanded numbered-spec lifecycle, and added Out-of-Scope and Amendment History sections.                                                                                 
  - Root CLAUDE.md overhauled: clarified the capability-spec vs numbered-spec split, added rules for keeping specs in sync with code changes, marked speckit-vendored paths as off-limits, and codified the numbered-spec hygiene protocol.                                                                                                         
  - Per-directory CLAUDE.md files added for each architectural layer and both migration trees, each restating the local rules and pointing to the relevant capability specs.                                                                                                                                                                   
  - specs/README.md extended with an "In-flight & recent features" index mapping all numbered specs to their capability specs, status, and a one-line brief.
  - Numbered specs 001–017 backfilled with the new **Capability**: field and accurate **Status**: values to match shipped reality. 
  - Added  specs/auditing/spec.md — capability spec scaffolded in api-conventions house style; covers all 015 FRs (CUD tracking, author capture, transactional revision, dedup, activity/history endpoints, per-entity snapshots, multi-vendor migrations) with Implemented via 014-auditing cross-references on each Requirement. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.