### PR TITLE
chore: extend CVE-2025-59250 expiration date in .trivyignore, bump org.bouncycastle:bcprov-jdk18on from 1.79 to 1.84, bump org.postgresql:postgresql from 42.7.8 to 42.7.11

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,2 @@
 #Fixed version already in use, false positive per https://github.com/aquasecurity/trivy/discussions/9745
-CVE-2025-59250 pkg:maven/com.microsoft.sqlserver/mssql-jdbc exp:2026-05-01
+CVE-2025-59250 pkg:maven/com.microsoft.sqlserver/mssql-jdbc exp:2026-12-31

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.h2database:h2:2.3.232'
-    implementation 'org.postgresql:postgresql:42.7.8'
+    implementation 'org.postgresql:postgresql:42.7.11'
     implementation 'com.microsoft.sqlserver:mssql-jdbc:13.2.1.jre11'
     implementation 'org.flywaydb:flyway-core:11.14.0'
     implementation 'org.flywaydb:flyway-database-postgresql:11.14.0'
@@ -187,6 +187,9 @@ dependencies {
             because("previous versions have vulnerabilities")
         }
         implementation ('tools.jackson.core:jackson-core:3.1.1') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation("org.bouncycastle:bcprov-jdk18on:1.84") {
             because("previous versions have vulnerabilities")
         }
         checkstyle ('org.codehaus.plexus:plexus-utils:4.0.3') {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.