### PR TITLE
chore: bump dependencies to secure versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,12 @@ dependencies {
         implementation ('io.netty:netty-codec-http:4.2.10.Final') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('io.netty:netty-codec-dns:4.2.13.Final') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('io.netty:netty-transport-native-epoll:4.2.13.Final') {
+            because("previous versions have vulnerabilities")
+        }
         implementation ('org.springframework:spring-webmvc:6.2.17') {
             because("previous versions have vulnerabilities")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             classpath ('com.fasterxml.jackson.core:jackson-core:2.21.1') {
                 because("previous versions have vulnerabilities")
             }
-            classpath ('io.netty:netty-codec-http2:4.2.11.Final') {
+            classpath ('io.netty:netty-codec-http2:4.2.13.Final') {
                 because("previous versions have vulnerabilities")
             }
             classpath ('io.netty:netty-codec-http:4.2.10.Final') {
@@ -121,7 +121,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.25.4'
     implementation 'org.apache.logging.log4j:log4j-jul:2.24.3'
 
-    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.5.12'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.5.14'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.opentelemetry:opentelemetry-sdk'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
@@ -159,7 +159,7 @@ dependencies {
         implementation ('io.projectreactor.netty:reactor-netty-http:1.2.8') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec-http2:4.2.11.Final') {
+        implementation ('io.netty:netty-codec-http2:4.2.13.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
- io.netty:netty-codec-http2 (4.2.11.Final -> 4.2.13.Final)
- org.springframework.boot:spring-boot-starter-actuator (3.5.12 -> 3.5.14)
- force io.netty:netty-codec-dns:4.2.13.Final
- force io.netty:netty-transport-native-epoll:4.2.13.Final

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.