### PR TITLE
fix: early failure detection for builder-push containers

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,7 +118,7 @@ app:
   image-name-format: ${IMAGE_NAME_FORMAT:app-%s}
   image-label: latest
   image-build-timeout-sec: 300
-  image-build-stop-timeout-sec: 30
+  image-build-stop-timeout-sec: 45
   image-build-logs-size-limit: 1000
   heartbeat-period-sec: 30
   max-error-log-lines: 20
@@ -254,7 +254,10 @@ app:
     name: builder-container
     image: ${app.builder-root-image}
     command:
-      - buildctl-daemonless.sh
+      - /bin/sh
+      - -c
+      - 'buildctl-daemonless.sh "$@"; CODE=$?; [ "$CODE" -ne 0 ] && touch /image-build/build-failed; exit $CODE'
+      - "--"
     args:
       - build
       - --frontend
@@ -272,7 +275,10 @@ app:
     name: builder-container
     image: ${app.builder-rootless-image}
     command:
-      - buildctl-daemonless.sh
+      - /bin/sh
+      - -c
+      - 'buildctl-daemonless.sh "$@"; CODE=$?; [ "$CODE" -ne 0 ] && touch /image-build/build-failed; exit $CODE'
+      - "--"
     env:
       - name: BUILDKITD_FLAGS
         value: "--oci-worker-no-process-sandbox"
@@ -311,6 +317,10 @@ app:
       RETRY=0
       echo "[push-container] Waiting for image tarball to be created and stable..."
       while [ $RETRY -lt $MAX_RETRIES ]; do
+        if [ -f "/image-build/build-failed" ]; then
+          echo "[push-container] ERROR: Builder reported failure. Exiting."
+          exit 1
+        fi
         if [ -f "$TAR_PATH" ]; then
           SIZE1=$(stat -c%s "$TAR_PATH")
           sleep ${SLEEP_INTERVAL_IN_SECONDS}

--- a/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/functional/tests/FullWorkflowWithMockedK8sClientFunctionalTest.java
@@ -423,7 +423,12 @@ public abstract class FullWorkflowWithMockedK8sClientFunctionalTest {
                 "dockerfile=/templates"
         ));
 
-        buildContainer.setCommand(Collections.singletonList("buildctl-daemonless.sh"));
+        buildContainer.setCommand(List.of(
+                "/bin/sh",
+                "-c",
+                "buildctl-daemonless.sh \"$@\"; CODE=$?; [ \"$CODE\" -ne 0 ] && touch /image-build/build-failed; exit $CODE",
+                "--"
+        ));
         buildContainer.setEnv(List.of(
                 new EnvVarBuilder()
                         .withName("BUILDKITD_FLAGS")
@@ -455,6 +460,10 @@ public abstract class FullWorkflowWithMockedK8sClientFunctionalTest {
             RETRY=0
             echo "[push-container] Waiting for image tarball to be created and stable..."
             while [ $RETRY -lt $MAX_RETRIES ]; do
+              if [ -f "/image-build/build-failed" ]; then
+                echo "[push-container] ERROR: Builder reported failure. Exiting."
+                exit 1
+              fi
               if [ -f "$TAR_PATH" ]; then
                 SIZE1=$(stat -c%s "$TAR_PATH")
                 sleep ${SLEEP_INTERVAL_IN_SECONDS}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #294 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
  - Wrapped buildctl-daemonless.sh in both the root and rootless builder containers with a /bin/sh -c invocation that touches /image-build/build-failed on non-zero exit (preserving the original exit code via "$@" so the runtime-appended --local context=... args still reach buildctl).
  - Added a sentinel check at the top of the push container's polling loop so it exits 1 immediately when the builder reports failure, instead of running out its full 120 × 2 s = 240 s retry budget waiting for a tarball that will never arrive.
  - Eliminates the ~8 min wait reported in #294: when the builder fails, the pod's containers now both terminate within one push-poll cycle (~2 s), the Job transitions to Failed, and the build status flips to BUILD_FAILED in seconds rather than minutes — no behavior change on the success path.
  - Side-change: increased image-build-stop-timeout-sec from 30s to 45s, since 30 is too low for dev env

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.