### PR TITLE
feat: show message of deployment pod's last terminated state

### DIFF
--- a/specs/deployments/spec.md
+++ b/specs/deployments/spec.md
@@ -339,7 +339,8 @@ Status: **Implemented**
 
 #### Scenario: All pods
 - **WHEN** `GET /api/v1/deployments/{id}/pods` is called
-- **THEN** all pod instances are returned; each `PodInfoDto` entry includes `name`, `createdAt`, `restartCount`, `lastTerminationReason`, `lastExitCode`, `lastSignal`, `lastFinishedAt`
+- **THEN** all pod instances are returned; each `PodInfoDto` entry includes `name`, `createdAt`, `restartCount`, `lastTerminationReason`, `lastTerminationMessage`, `lastExitCode`, `lastSignal`, `lastFinishedAt`
+- **AND** `lastTerminationMessage` carries the container's `lastState.terminated.message` (or `state.terminated.message`) from the same termination as the other `lastTermination*`/`lastExitCode` fields, when present
 
 #### Scenario: Active pods only
 - **WHEN** `GET /api/v1/deployments/{id}/active-pods` is called

--- a/src/main/java/com/epam/aidial/deployment/manager/model/PodInfo.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/model/PodInfo.java
@@ -17,6 +17,8 @@ public class PodInfo {
     @Nullable
     private String lastTerminationReason;
     @Nullable
+    private String lastTerminationMessage;
+    @Nullable
     private Integer lastExitCode;
     @Nullable
     private Integer lastSignal;

--- a/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/service/deployment/AbstractDeploymentManager.java
@@ -482,6 +482,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
                 Instant.parse(pod.getMetadata().getCreationTimestamp()),
                 containerInfo.restartCount(),
                 containerInfo.lastTerminationReason(),
+                containerInfo.lastTerminationMessage(),
                 containerInfo.lastExitCode(),
                 containerInfo.lastSignal(),
                 containerInfo.lastFinishedAt()
@@ -490,7 +491,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
 
     private ContainerInfo extractContainerInfo(List<ContainerStatus> containerStatuses) {
         if (CollectionUtils.isEmpty(containerStatuses)) {
-            return new ContainerInfo(0, null, null, null, null);
+            return new ContainerInfo(0, null, null, null, null, null);
         }
 
         int totalRestartCount = 0;
@@ -513,13 +514,14 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
             return new ContainerInfo(
                     totalRestartCount,
                     mostRecentTermination.getReason(),
+                    mostRecentTermination.getMessage(),
                     mostRecentTermination.getExitCode(),
                     mostRecentTermination.getSignal(),
                     K8sParseUtils.parseInstant(mostRecentTermination.getFinishedAt())
             );
         }
 
-        return new ContainerInfo(totalRestartCount, null, null, null, null);
+        return new ContainerInfo(totalRestartCount, null, null, null, null, null);
     }
 
     private ContainerStateTerminated getTerminatedState(ContainerState state) {
@@ -872,6 +874,7 @@ public abstract class AbstractDeploymentManager<D extends Deployment, S> impleme
     private record ContainerInfo(
             int restartCount,
             String lastTerminationReason,
+            String lastTerminationMessage,
             Integer lastExitCode,
             Integer lastSignal,
             Instant lastFinishedAt

--- a/src/main/java/com/epam/aidial/deployment/manager/web/dto/PodInfoDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/web/dto/PodInfoDto.java
@@ -9,6 +9,7 @@ public record PodInfoDto(
         @NotNull Instant createdAt,
         int restartCount,
         String lastTerminationReason,
+        String lastTerminationMessage,
         Integer lastExitCode,
         Integer lastSignal,
         Instant lastFinishedAt

--- a/src/test/java/com/epam/aidial/deployment/manager/web/controller/none/DeploymentControllerTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/web/controller/none/DeploymentControllerTest.java
@@ -707,7 +707,8 @@ class DeploymentControllerTest extends AbstractControllerNoneSecureTest {
         var dtoJson = ResourceUtils.readResource("/mcp/deployment/pods_with_restart_info_response.json");
         var createdAt = Instant.parse("2023-01-01T12:00:00Z");
         var finishedAt = Instant.parse("2023-01-01T12:10:00Z");
-        var podInfo = new PodInfo("pod-1", createdAt, 5, "OOMKilled", 137, 9, finishedAt);
+        var podInfo = new PodInfo("pod-1", createdAt, 5, "OOMKilled",
+                "Container exceeded its memory limit", 137, 9, finishedAt);
 
         when(deploymentService.getInstances(DEPLOYMENT_ID)).thenReturn(List.of(podInfo));
 
@@ -723,7 +724,7 @@ class DeploymentControllerTest extends AbstractControllerNoneSecureTest {
         var dtoJson = ResourceUtils.readResource("/mcp/deployment/pods_without_termination_info_response.json");
         var createdAt = Instant.parse("2023-01-01T12:00:00Z");
         var finishedAt = Instant.parse("2023-01-01T12:10:00Z");
-        var podInfo = new PodInfo("pod-2", createdAt, 0, null, null, null, finishedAt);
+        var podInfo = new PodInfo("pod-2", createdAt, 0, null, null, null, null, finishedAt);
 
         when(deploymentService.getInstances(DEPLOYMENT_ID)).thenReturn(List.of(podInfo));
 
@@ -739,7 +740,7 @@ class DeploymentControllerTest extends AbstractControllerNoneSecureTest {
         var dtoJson = ResourceUtils.readResource("/mcp/deployment/active_pods_response.json");
         var createdAt = Instant.parse("2023-01-01T12:00:00Z");
         var finishedAt = Instant.parse("2023-01-01T12:10:00Z");
-        var podInfo = new PodInfo("pod-3", createdAt, 2, "Error", 1, null, finishedAt);
+        var podInfo = new PodInfo("pod-3", createdAt, 2, "Error", null, 1, null, finishedAt);
 
         when(deploymentService.getActiveInstances(DEPLOYMENT_ID)).thenReturn(List.of(podInfo));
 

--- a/src/test/resources/mcp/deployment/pods_with_restart_info_response.json
+++ b/src/test/resources/mcp/deployment/pods_with_restart_info_response.json
@@ -4,6 +4,7 @@
     "createdAt": 1672574400000,
     "restartCount": 5,
     "lastTerminationReason": "OOMKilled",
+    "lastTerminationMessage": "Container exceeded its memory limit",
     "lastExitCode": 137,
     "lastSignal": 9
   }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #344 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Pod introspection now surfaces the container's last termination message — the human-readable failure reason Kubernetes records when a container exits (e.g. during a crash-loop) — alongside the existing termination reason, exit code, and signal.
- The new lastTerminationMessage is exposed on the GET /api/v1/deployments/{id}/pods and /active-pods responses, so clients can see why a pod failed without manually inspecting the pod definition.
- Updated the deployments capability spec and pod-info tests/fixtures to cover the new field.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.