### PR TITLE
chore: bump dependencies to secure versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,10 @@ buildscript {
             classpath ('com.fasterxml.jackson.core:jackson-core:2.21.1') {
                 because("previous versions have vulnerabilities")
             }
-            classpath ('io.netty:netty-codec-http2:4.2.13.Final') {
+            classpath ('io.netty:netty-codec-http2:4.2.15.Final') {
                 because("previous versions have vulnerabilities")
             }
-            classpath ('io.netty:netty-codec-http:4.2.10.Final') {
+            classpath ('io.netty:netty-codec-http:4.2.15.Final') {
                 because("previous versions have vulnerabilities")
             }
         }
@@ -68,6 +68,8 @@ dependencies {
     implementation platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
     // overrides the Boot-BOM-managed OpenTelemetry 1.55.0 — unbounded memory allocation in W3C baggage propagation, patched in 1.62.0
     implementation platform('io.opentelemetry:opentelemetry-bom:1.62.0')
+    // aligns every io.netty module (overriding the Boot BOM) to one patched version — covers multiple HIGH CVEs
+    implementation platform('io.netty:netty-bom:4.2.15.Final')
 
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
@@ -166,22 +168,7 @@ dependencies {
         implementation ('io.projectreactor.netty:reactor-netty-http:1.2.8') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec-http2:4.2.13.Final') {
-            because("previous versions have vulnerabilities")
-        }
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {
-            because("previous versions have vulnerabilities")
-        }
-        implementation ('io.netty:netty-codec-dns:4.2.13.Final') {
-            because("previous versions have vulnerabilities")
-        }
-        implementation ('io.netty:netty-codec-http3:4.2.13.Final') {
-            because("previous versions have vulnerabilities")
-        }
-        implementation ('io.netty:netty-handler-proxy:4.2.13.Final') {
-            because("previous versions have vulnerabilities")
-        }
-        implementation ('io.netty:netty-transport-native-epoll:4.2.13.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation ('com.fasterxml.jackson.core:jackson-core:2.21.1') {


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
  - Added implementation platform('io.netty:netty-bom:4.2.15.Final') (mirroring the existing opentelemetry-bom override pattern); CVEs it resolves: CVE-2026-44894, -44892, -44249, -45416, -45674, -47691.
  - Removed the now-redundant individual io.netty:* constraints (netty-codec-http2, -codec-dns, -codec-http3, -handler-proxy, -transport-native-epoll) — all superseded by the BOM. Kept grpc-netty-shaded (shaded Netty, not BOM-managed).
  - Bumped the two buildscript classpath Netty pins (netty-codec-http2 4.2.13→4.2.15, netty-codec-http 4.2.10→4.2.15) for consistency. These are build-time only, but were pinning the same modules to older versions.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.