### PR TITLE
chore: bump libcrypto3 to version 3.5.7-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --chown=appuser:appuser docker-entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-RUN apk add --no-cache zlib=1.3.2-r0 libcrypto3=3.5.6-r0 libssl3=3.5.6-r0
+RUN apk add --no-cache zlib=1.3.2-r0 libcrypto3=3.5.7-r0 libssl3=3.5.7-r0
 
 USER appuser
 


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
Bump libcrypto3 dependency version from 3.5.6-r0 to 3.5.7-r0.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.