### PR TITLE
fix: bind image entrypoint/cmd from container config blob

### DIFF
--- a/src/main/java/com/epam/aidial/deployment/manager/docker/dto/ContainerConfigurationTemplateDto.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/docker/dto/ContainerConfigurationTemplateDto.java
@@ -13,7 +13,7 @@ import java.util.List;
 )
 public class ContainerConfigurationTemplateDto {
 
-    private final ConfigurationObjectTemplate config = new ConfigurationObjectTemplate();
+    private ConfigurationObjectTemplate config = new ConfigurationObjectTemplate();
 
     @Data
     public static class ConfigurationObjectTemplate {

--- a/src/test/java/com/epam/aidial/deployment/manager/docker/DockerRegistryClientTest.java
+++ b/src/test/java/com/epam/aidial/deployment/manager/docker/DockerRegistryClientTest.java
@@ -1,8 +1,8 @@
 package com.epam.aidial.deployment.manager.docker;
 
 import com.epam.aidial.deployment.manager.configuration.DockerAuthScheme;
+import com.epam.aidial.deployment.manager.configuration.JsonMapperConfiguration;
 import com.epam.aidial.deployment.manager.configuration.RegistryProperties;
-import com.epam.aidial.deployment.manager.docker.dto.ContainerConfigurationTemplateDto;
 import com.epam.aidial.deployment.manager.model.ImageEntrypoint;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
@@ -47,8 +47,7 @@ class DockerRegistryClientTest {
 
     private DockerRegistryClient dockerRegistryClient;
 
-    @Mock
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = JsonMapperConfiguration.createJsonMapper();
     @Mock
     private RegistryClient registryClient;
     @Mock
@@ -100,15 +99,9 @@ class DockerRegistryClientTest {
             var descriptorDigest = mock(DescriptorDigest.class);
             when(configDescriptor.getDigest()).thenReturn(descriptorDigest);
 
-            // Mock blob
+            // Mock blob — parsed by the real project ObjectMapper, exercising the actual Jackson binding
             var blob = Blobs.from(new ByteArrayInputStream("{\"config\":{\"Entrypoint\":[\"sh\"],\"Cmd\":[\"-c\",\"echo hello\"]}}".getBytes()));
             when(registryClient.pullBlob(eq(descriptorDigest), any(), any())).thenReturn(blob);
-
-            // Mock object mapper
-            var configTemplate = new ContainerConfigurationTemplateDto();
-            configTemplate.getConfig().setEntrypoint(List.of("sh"));
-            configTemplate.getConfig().setCmd(List.of("-c", "echo hello"));
-            when(objectMapper.readValue(any(byte[].class), eq(ContainerConfigurationTemplateDto.class))).thenReturn(configTemplate);
 
             // When
             ImageEntrypoint result = dockerRegistryClient.getEntrypoint(imageName);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #352

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Follow-up to the Spring Boot 4 / Jackson 3 (`tools.jackson`) upgrade.

`ContainerConfigurationTemplateDto.config` was declared `final`, so Lombok `@Data` generated no setter. Combined with the project mapper disabling `DETECT_PARAMETER_NAMES` (no constructor binding), Jackson had no mutator for the `config` property and silently kept the inline-initialized empty object — so `DockerRegistryClient.getEntrypoint(...)` always returned an empty entrypoint/cmd.

- Drop `final` on `config` so `@Data` generates the setter and Jackson binds the nested container config.
- Switch `DockerRegistryClientTest` to the real project `ObjectMapper` (`JsonMapperConfiguration.createJsonMapper()`) instead of mocking `readValue`, so the actual Jackson binding is exercised. Verified the test fails against the old `final` field, locking in the regression.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
