### PR TITLE
fix: bump netty to 4.2.16.Final to resolve HIGH CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,10 @@ buildscript {
             classpath ('com.fasterxml.jackson.core:jackson-core:2.21.4') {
                 because("previous versions have vulnerabilities")
             }
-            classpath ('io.netty:netty-codec-http2:4.2.15.Final') {
+            classpath ('io.netty:netty-codec-http2:4.2.16.Final') {
                 because("previous versions have vulnerabilities")
             }
-            classpath ('io.netty:netty-codec-http:4.2.15.Final') {
+            classpath ('io.netty:netty-codec-http:4.2.16.Final') {
                 because("previous versions have vulnerabilities")
             }
         }
@@ -69,7 +69,7 @@ dependencies {
     // overrides the Boot-BOM-managed OpenTelemetry 1.55.0 — unbounded memory allocation in W3C baggage propagation, patched in 1.62.0
     implementation platform('io.opentelemetry:opentelemetry-bom:1.62.0')
     // aligns every io.netty module (overriding the Boot BOM) to one patched version — covers multiple HIGH CVEs
-    implementation platform('io.netty:netty-bom:4.2.15.Final')
+    implementation platform('io.netty:netty-bom:4.2.16.Final')
     // overrides the Boot-BOM-managed Jackson 3 (3.1.2) — PolymorphicTypeValidator/array-subtype allowlist
     // bypasses (CVE-2026-54512, CVE-2026-54513), patched in 3.1.4
     implementation platform('tools.jackson:jackson-bom:3.1.4')


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->
The `development` Release Workflow fails at the Trivy image scan: `io.netty` 4.2.15.Final in `app.jar` carries 5 HIGH vulnerabilities — CVE-2026-59901 (Bzip2Decoder infinite loop), CVE-2026-55831, CVE-2026-55833, CVE-2026-56745 (SpdyHttpDecoder ByteBuf leak), and CVE-2026-56816 (HTTP/3 memory exhaustion). All are fixed in 4.2.16.Final.

- Bumped the `io.netty:netty-bom` platform from 4.2.15.Final to 4.2.16.Final so every Netty module on the runtime classpath aligns to the patched version (verified via `gradlew dependencies`).
- Bumped the matching buildscript classpath constraints (`netty-codec-http`, `netty-codec-http2`) to 4.2.16.Final for consistency.

`./gradlew testFast` passes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
