### PR TITLE
fix: bump spring boot to 4.0.7 and patch jackson CVEs

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,14 +1,16 @@
 <!-- Sync Impact Report
-Version change: 1.4.0 → 1.5.0 (MINOR: Spring Boot 4 platform upgrade — Tech Stack section rewritten for Boot 4.0.6 / Framework 7 / Jackson 3)
+Version change: 1.5.0 → 1.5.1 (PATCH: version-pin refresh, no rule changes)
 Modified sections:
-  - Tech Stack (Spring Boot 3.5.10 → 4.0.6; Gradle 8.13 → 8.14.5; removed the actuator 3.5.14 deliberate-override note — the Boot 4 BOM supersedes it; Jackson 2 → Jackson 3 (`tools.jackson`) as the application serialization stack, Jackson 2 retained only as a transitive dependency of third-party SDKs and for Hibernate JSON column mapping; spring-retry replaced by Spring Framework 7 core retry (`org.springframework.core.retry`); community `opentelemetry-spring-boot-starter` replaced by the official `spring-boot-starter-opentelemetry`; ShedLock 6.3.0 → 7.7.0; SpringDoc 2.8.5 → 3.0.3; MapStruct 1.6.0 → 1.6.3; ArchUnit 1.3.0 → 1.4.2; Flyway via `spring-boot-starter-flyway` (BOM-managed); Testcontainers 2.x (BOM-managed); log4j2 modules aligned to 2.25.4; the global `commons-logging` exclusion was removed because Spring Framework 7 depends on commons-logging 1.3 directly; jjwt (test-only) 0.9.1 → 0.13.0, which also removed the javax.xml.bind/jaxb 2.x dependencies)
-  - Tooling Commands (Docker build stage image gradle:8.13 → gradle:8.14.5, pinned to the exact wrapper version)
+  - Tech Stack (Spring Boot 4.0.6 → 4.0.7 — maintenance release with two auto-configuration CVE fixes
+    (CVE-2026-40992, CVE-2026-41001) and dependency upgrades, among them Hibernate ORM 7.2.12 → 7.2.19; PostgreSQL
+    driver 42.7.11 → 42.7.12, aligning the pin with build.gradle after #393; Jackson 2 security floor restated as
+    the `jackson-core` 2.21.4 constraint, aligning with build.gradle)
 Templates requiring updates:
   ✅ .specify/memory/constitution.md (this file)
   ✅ No template changes needed — speckit reads constitution directly
   ✅ No [PLACEHOLDER] tokens remain
 Follow-up TODOs:
-  - none — the previous jjwt 0.9.1 backlog item was resolved by this upgrade
+  - none
 -->
 
 # DIAL Deployment Manager Backend Constitution
@@ -25,7 +27,7 @@ Constitutionally-significant libraries (any upgrade MUST go through a PR with a 
 - **Code generation**: Lombok via `io.freefair.lombok` plugin 8.10, MapStruct 1.6.3
 - **Database migrations**: Flyway via `spring-boot-starter-flyway` (version BOM-managed) plus `flyway-database-postgresql` and `flyway-sqlserver`
 - **Kubernetes**: Fabric8 Kubernetes Client 7.5.2, Fabric8 Knative Client 7.5.2, `io.kubernetes:client-java` 22.0.0
-- **Serialization**: Jackson 3 (`tools.jackson`, BOM-managed) is the application serialization stack; `com.fasterxml.jackson.annotation` annotations are shared by both generations. Jackson 2 is retained deliberately for two frozen consumers — legacy Java Flyway migrations (`db.migration.MigrationJsonMapper`; see `src/main/java/db/migration/CLAUDE.md`) and Hibernate's JSON column mapping — plus transitively via third-party SDKs (Fabric8, MCP SDK, jib); its security floor is enforced via the `jackson-core` 2.21.1 constraint.
+- **Serialization**: Jackson 3 (`tools.jackson`, BOM-managed) is the application serialization stack; `com.fasterxml.jackson.annotation` annotations are shared by both generations. Jackson 2 is retained deliberately for two frozen consumers — legacy Java Flyway migrations (`db.migration.MigrationJsonMapper`; see `src/main/java/db/migration/CLAUDE.md`) and Hibernate's JSON column mapping — plus transitively via third-party SDKs (Fabric8, MCP SDK, jib); its security floor is enforced via the `jackson-core` 2.21.4 constraint.
 - **Retry**: Spring Framework 7 core retry (`org.springframework.core.retry`); `spring-retry` MUST NOT be reintroduced
 - **Logging**: Log4j2 2.25.4 (`log4j-core`, `log4j-slf4j2-impl`, `log4j-jul`); `spring-boot-starter-logging` MUST be excluded globally. `commons-logging` MUST NOT be excluded — Spring Framework 7 depends on it directly.
 - **Observability**: official `spring-boot-starter-opentelemetry`, Micrometer + Prometheus, `opentelemetry-log4j-appender-2.17` (version aligned with the OpenTelemetry API pinned via the `opentelemetry-bom` platform in build.gradle — a security floor over the Boot-BOM-managed version; installed programmatically by `OpenTelemetryLogAppenderConfiguration`)
@@ -33,7 +35,7 @@ Constitutionally-significant libraries (any upgrade MUST go through a PR with a 
 - **Distributed locking**: ShedLock 7.7.0 (JDBC provider)
 - **API docs**: SpringDoc OpenAPI 3.0.3
 - **Security**: Spring Security + OAuth2 Resource Server (`spring-boot-starter-security-oauth2-resource-server`); Azure Identity 1.18.0. The supported OIDC provider list lives in `specs/security/spec.md`.
-- **Databases supported**: H2 2.3.232 (dev/test — pinned deliberately: existing encrypted H2 data files must stay readable), PostgreSQL 42.7.11, SQL Server 13.2.1 (`mssql-jdbc`)
+- **Databases supported**: H2 2.3.232 (dev/test — pinned deliberately: existing encrypted H2 data files must stay readable), PostgreSQL 42.7.12, SQL Server 13.2.1 (`mssql-jdbc`)
 - **Auditing**: Hibernate Envers (Hibernate ORM 7, BOM-managed) — anchors the `auditing` capability spec (numbered feature 014)
 - **Code quality**: Checkstyle 10.21.4 (Google Java Style profile), `-Werror` on all Java compilation, ArchUnit 1.4.2 (architectural rules in `ArchitectureTest`)
 - **Style helpers**: Apache Commons Lang3 3.18.0 and Commons Collections4 4.5.0-M3 — Code Style mandates their `StringUtils` and `CollectionUtils` over inline null-and-empty checks
@@ -302,9 +304,10 @@ Per-directory `CLAUDE.md` files exist for each architectural layer (`web/`, `ser
 
 | Version | Date | Summary |
 |---|---|---|
+| 1.5.1 | 2026-08-19 | Version-pin refresh: Spring Boot 4.0.6 → 4.0.7 (pulls Hibernate ORM 7.2.12 → 7.2.19, which required `SqlServerJsonAsVarcharTypeContributor` to keep JSON columns on `varchar(max)`); PostgreSQL driver pin 42.7.11 → 42.7.12 and Jackson 2 floor 2.21.1 → 2.21.4, both aligning the document with build.gradle |
 | 1.5.0 | 2026-06-03 | Spring Boot 4 platform upgrade: Boot 4.0.6 / Framework 7 / Hibernate ORM 7 / Jackson 3 (`tools.jackson`); Gradle 8.14.5; removed actuator BOM-override note; spring-retry → Framework 7 core retry; community OTel starter → official `spring-boot-starter-opentelemetry`; ShedLock 7.7.0; SpringDoc 3.0.3; ArchUnit 1.4.2; Testcontainers 2.x; jjwt 0.13.0 (test) and jaxb 2.x removal |
 | 1.4.0 | 2026-04-30 | Reframed Tech Stack (build.gradle canonical); added inline enforcement tags; softened CONFIG_REST_SECURITY_MODE to SHOULD; aligned `@LogExecution` Spring-component list with ArchUnit; deduped Anti-pattern #4; clarified K8s-API polling vs scheduled tasks; expanded numbered-spec lifecycle (Cancelled, Superseded); added Out of Scope and Amendment History sections |
 | 1.3.0 | 2026-04-29 | Per-directory CLAUDE.md acknowledgment; added Capability ↔ numbered-spec cross-link rule |
 | ≤1.2.2 | — | See `git log .specify/memory/constitution.md` |
 
-**Version**: 1.5.0 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-06-03
+**Version**: 1.5.1 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-08-19

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -3,8 +3,9 @@ Version change: 1.5.0 → 1.5.1 (PATCH: version-pin refresh, no rule changes)
 Modified sections:
   - Tech Stack (Spring Boot 4.0.6 → 4.0.7 — maintenance release with two auto-configuration CVE fixes
     (CVE-2026-40992, CVE-2026-41001) and dependency upgrades, among them Hibernate ORM 7.2.12 → 7.2.19; PostgreSQL
-    driver 42.7.11 → 42.7.12, aligning the pin with build.gradle after #393; Jackson 2 security floor restated as
-    the `jackson-core` 2.21.4 constraint, aligning with build.gradle)
+    driver 42.7.11 → 42.7.12, aligning the pin with build.gradle after #393; Jackson 2 security floor 2.21.1 →
+    2.21.6 and Jackson 3 held at 3.1.6 over the Boot-BOM 3.1.4 — CVE-2026-59889 / GHSA-mhm7-754m-9p8w affect both
+    generations)
 Templates requiring updates:
   ✅ .specify/memory/constitution.md (this file)
   ✅ No template changes needed — speckit reads constitution directly
@@ -27,7 +28,7 @@ Constitutionally-significant libraries (any upgrade MUST go through a PR with a 
 - **Code generation**: Lombok via `io.freefair.lombok` plugin 8.10, MapStruct 1.6.3
 - **Database migrations**: Flyway via `spring-boot-starter-flyway` (version BOM-managed) plus `flyway-database-postgresql` and `flyway-sqlserver`
 - **Kubernetes**: Fabric8 Kubernetes Client 7.5.2, Fabric8 Knative Client 7.5.2, `io.kubernetes:client-java` 22.0.0
-- **Serialization**: Jackson 3 (`tools.jackson`, BOM-managed) is the application serialization stack; `com.fasterxml.jackson.annotation` annotations are shared by both generations. Jackson 2 is retained deliberately for two frozen consumers — legacy Java Flyway migrations (`db.migration.MigrationJsonMapper`; see `src/main/java/db/migration/CLAUDE.md`) and Hibernate's JSON column mapping — plus transitively via third-party SDKs (Fabric8, MCP SDK, jib); its security floor is enforced via the `jackson-core` 2.21.4 constraint.
+- **Serialization**: Jackson 3 (`tools.jackson`, BOM-managed) is the application serialization stack; `com.fasterxml.jackson.annotation` annotations are shared by both generations. Jackson 2 is retained deliberately for two frozen consumers — legacy Java Flyway migrations (`db.migration.MigrationJsonMapper`; see `src/main/java/db/migration/CLAUDE.md`) and Hibernate's JSON column mapping — plus transitively via third-party SDKs (Fabric8, MCP SDK, jib); its security floor is enforced via the `jackson-core` 2.21.6 constraint.
 - **Retry**: Spring Framework 7 core retry (`org.springframework.core.retry`); `spring-retry` MUST NOT be reintroduced
 - **Logging**: Log4j2 2.25.4 (`log4j-core`, `log4j-slf4j2-impl`, `log4j-jul`); `spring-boot-starter-logging` MUST be excluded globally. `commons-logging` MUST NOT be excluded — Spring Framework 7 depends on it directly.
 - **Observability**: official `spring-boot-starter-opentelemetry`, Micrometer + Prometheus, `opentelemetry-log4j-appender-2.17` (version aligned with the OpenTelemetry API pinned via the `opentelemetry-bom` platform in build.gradle — a security floor over the Boot-BOM-managed version; installed programmatically by `OpenTelemetryLogAppenderConfiguration`)
@@ -304,7 +305,7 @@ Per-directory `CLAUDE.md` files exist for each architectural layer (`web/`, `ser
 
 | Version | Date | Summary |
 |---|---|---|
-| 1.5.1 | 2026-08-19 | Version-pin refresh: Spring Boot 4.0.6 → 4.0.7 (pulls Hibernate ORM 7.2.12 → 7.2.19, which required `SqlServerJsonAsVarcharTypeContributor` to keep JSON columns on `varchar(max)`); PostgreSQL driver pin 42.7.11 → 42.7.12 and Jackson 2 floor 2.21.1 → 2.21.4, both aligning the document with build.gradle |
+| 1.5.1 | 2026-08-19 | Version-pin refresh: Spring Boot 4.0.6 → 4.0.7 (pulls Hibernate ORM 7.2.12 → 7.2.19, which required `SqlServerJsonAsVarcharTypeContributor` to keep JSON columns on `varchar(max)`); PostgreSQL driver pin 42.7.11 → 42.7.12 aligning the document with build.gradle; Jackson floors raised to 2.21.6 / 3.1.6 for CVE-2026-59889 and GHSA-mhm7-754m-9p8w |
 | 1.5.0 | 2026-06-03 | Spring Boot 4 platform upgrade: Boot 4.0.6 / Framework 7 / Hibernate ORM 7 / Jackson 3 (`tools.jackson`); Gradle 8.14.5; removed actuator BOM-override note; spring-retry → Framework 7 core retry; community OTel starter → official `spring-boot-starter-opentelemetry`; ShedLock 7.7.0; SpringDoc 3.0.3; ArchUnit 1.4.2; Testcontainers 2.x; jjwt 0.13.0 (test) and jaxb 2.x removal |
 | 1.4.0 | 2026-04-30 | Reframed Tech Stack (build.gradle canonical); added inline enforcement tags; softened CONFIG_REST_SECURITY_MODE to SHOULD; aligned `@LogExecution` Spring-component list with ArchUnit; deduped Anti-pattern #4; clarified K8s-API polling vs scheduled tasks; expanded numbered-spec lifecycle (Cancelled, Superseded); added Out of Scope and Amendment History sections |
 | 1.3.0 | 2026-04-29 | Per-directory CLAUDE.md acknowledgment; added Capability ↔ numbered-spec cross-link rule |

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -21,7 +21,7 @@ The base package for all production sources MUST be `com.epam.aidial.deployment.
 
 Constitutionally-significant libraries (any upgrade MUST go through a PR with a security or feature rationale):
 
-- **Runtime**: Java 21, Spring Boot 4.0.6 (Spring Framework 7), Gradle 8.14.5
+- **Runtime**: Java 21, Spring Boot 4.0.7 (Spring Framework 7), Gradle 8.14.5
 - **Code generation**: Lombok via `io.freefair.lombok` plugin 8.10, MapStruct 1.6.3
 - **Database migrations**: Flyway via `spring-boot-starter-flyway` (version BOM-managed) plus `flyway-database-postgresql` and `flyway-sqlserver`
 - **Kubernetes**: Fabric8 Kubernetes Client 7.5.2, Fabric8 Knative Client 7.5.2, `io.kubernetes:client-java` 22.0.0

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
             classpath ('org.apache.commons:commons-lang3:3.18.0') {
                 because("previous versions have vulnerabilities")
             }
-            classpath ('com.fasterxml.jackson.core:jackson-core:2.21.4') {
+            classpath ('com.fasterxml.jackson.core:jackson-core:2.21.6') {
                 because("previous versions have vulnerabilities")
             }
             classpath ('io.netty:netty-codec-http2:4.2.16.Final') {
@@ -70,9 +70,9 @@ dependencies {
     implementation platform('io.opentelemetry:opentelemetry-bom:1.62.0')
     // aligns every io.netty module (overriding the Boot BOM) to one patched version — covers multiple HIGH CVEs
     implementation platform('io.netty:netty-bom:4.2.16.Final')
-    // pins the Jackson 3 floor at 3.1.4 — PolymorphicTypeValidator/array-subtype allowlist
-    // bypasses (CVE-2026-54512, CVE-2026-54513), patched in 3.1.4
-    implementation platform('tools.jackson:jackson-bom:3.1.4')
+    // overrides the Boot-BOM-managed Jackson 3 (3.1.4) — @JsonView bypassed for @JsonUnwrapped container
+    // properties on deserialization (CVE-2026-59889), patched in 3.1.5; 3.1.6 is the latest 3.1.x patch
+    implementation platform('tools.jackson:jackson-bom:3.1.6')
 
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
@@ -131,10 +131,12 @@ dependencies {
     // Jackson 2 is intentionally kept: legacy Java Flyway migrations are pinned to it so they keep
     // executing the exact code they shipped with (db.migration.MigrationJsonMapper), and Hibernate's
     // JSON column mapping (@JdbcTypeCode(SqlTypes.JSON)) still uses Jackson 2 with
-    // constructor-parameter-name detection, which spring-boot-starter-json used to provide before Jackson 3
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.4'
-    runtimeOnly 'com.fasterxml.jackson.module:jackson-module-parameter-names:2.21.4'
+    // constructor-parameter-name detection, which spring-boot-starter-json used to provide before Jackson 3.
+    // Held above the Boot-BOM-managed 2.21.4, which is affected by the same @JsonUnwrapped/@JsonView bypasses
+    // as Jackson 3 (CVE-2026-59889, GHSA-mhm7-754m-9p8w), both patched in 2.21.5
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.6'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.6'
+    runtimeOnly 'com.fasterxml.jackson.module:jackson-module-parameter-names:2.21.6'
     implementation 'com.github.f4b6a3:uuid-creator:6.0.0'
 
     implementation 'org.mapstruct:mapstruct:1.6.3'
@@ -174,7 +176,7 @@ dependencies {
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {
             because("previous versions have vulnerabilities")
         }
-        implementation ('com.fasterxml.jackson.core:jackson-core:2.21.4') {
+        implementation ('com.fasterxml.jackson.core:jackson-core:2.21.6') {
             because("transitive Jackson 2 from fabric8/MCP/jib — previous versions have vulnerabilities")
         }
         implementation("org.bouncycastle:bcprov-jdk18on:1.84") {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'java'
     id 'checkstyle'
     id 'io.freefair.lombok' version '8.10'
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
     id 'io.fabric8.java-generator' version "${fabric8_kubernetes_client_version}"
 }
 
@@ -70,7 +70,7 @@ dependencies {
     implementation platform('io.opentelemetry:opentelemetry-bom:1.62.0')
     // aligns every io.netty module (overriding the Boot BOM) to one patched version — covers multiple HIGH CVEs
     implementation platform('io.netty:netty-bom:4.2.16.Final')
-    // overrides the Boot-BOM-managed Jackson 3 (3.1.2) — PolymorphicTypeValidator/array-subtype allowlist
+    // pins the Jackson 3 floor at 3.1.4 — PolymorphicTypeValidator/array-subtype allowlist
     // bypasses (CVE-2026-54512, CVE-2026-54513), patched in 3.1.4
     implementation platform('tools.jackson:jackson-bom:3.1.4')
 

--- a/specs/database-and-migrations/spec.md
+++ b/specs/database-and-migrations/spec.md
@@ -109,10 +109,36 @@ Status: **Implemented**
 - **WHEN** the application starts
 - **THEN** Hibernate validates the schema against entity mappings; it does NOT create or alter tables
 
+### Requirement: JSON attribute storage type is pinned per vendor
+Attributes annotated `@JdbcTypeCode(SqlTypes.JSON)` SHALL be stored as `jsonb` on POSTGRES, native `json` on H2,
+and `varchar(max)` on MS_SQL_SERVER.
+
+The SQL Server mapping is pinned explicitly by `SqlServerJsonAsVarcharTypeContributor`, registered through
+`META-INF/services/org.hibernate.boot.model.TypeContributor`. From Hibernate 7.2.19 onwards
+`AbstractTransactSQLDialect` registers the nationalized JSON descriptor, which would resolve these attributes to
+`nvarchar(max)` and fail `ddl-auto: validate` against the `varchar(max)` columns the migrations create. The
+contributor MUST be registered as a service, not via the `hibernate.type_contributors` property: property-supplied
+contributors run at `MetadataBuilder` configuration time, before dialect contributions overwrite the registration.
+
+Known limitation: `varchar(max)` cannot represent characters outside the column collation's code page, so non-ASCII
+content in JSON attributes is subject to lossy conversion on MS_SQL_SERVER. Removing the contributor requires
+converting all JSON columns in the `MS_SQL_SERVER` migration tree to `NVARCHAR(MAX)` in the same change.
+
+Status: **Implemented**
+
+#### Scenario: JSON attribute validated on SQL Server
+- **WHEN** the application starts with `DATASOURCE_VENDOR=MS_SQL_SERVER`
+- **THEN** JSON attributes resolve to `varchar(max)` and Hibernate schema validation passes
+
+#### Scenario: Other vendors keep their native JSON type
+- **WHEN** the application starts with `DATASOURCE_VENDOR=POSTGRES` or `DATASOURCE_VENDOR=H2`
+- **THEN** the contributor does not apply, and JSON attributes resolve to `jsonb` and `json` respectively
+
 ## Implementation Notes
 - Config property: `DATASOURCE_VENDOR` (`H2` | `POSTGRES` | `MS_SQL_SERVER`)
 - Flyway config: `baseline-on-migrate: true`, `baseline-version: 1.1`
 - Datasource configuration: `com.epam.aidial.deployment.manager.configuration.datasource.*`
+- SQL Server JSON type pin: `configuration/datasource/SqlServerJsonAsVarcharTypeContributor` + `src/main/resources/META-INF/services/org.hibernate.boot.model.TypeContributor`
 - JPA entities: `com.epam.aidial.deployment.manager.dao.entity.*`
 - JPA repository interfaces: `com.epam.aidial.deployment.manager.dao.jpa.*` (extend `JpaRepository`)
 - Custom repository wrappers: `com.epam.aidial.deployment.manager.dao.repository.*` (delegate to JPA repos, add domain mapping)

--- a/specs/database-and-migrations/spec.md
+++ b/specs/database-and-migrations/spec.md
@@ -111,18 +111,36 @@ Status: **Implemented**
 
 ### Requirement: JSON attribute storage type is pinned per vendor
 Attributes annotated `@JdbcTypeCode(SqlTypes.JSON)` SHALL be stored as `jsonb` on POSTGRES, native `json` on H2,
-and `varchar(max)` on MS_SQL_SERVER.
+and `varchar(max)` on MS_SQL_SERVER. Known deviation: the three `allowed_domains` base columns
+(`domain_whitelist`, `image_definition`, `deployment`) are plain `json` on POSTGRES, created that way by
+`V1.39__AddAllowedDomainsToImageDefinitionAndDeployment.sql`; their `_aud` counterparts are `jsonb`. Schema
+validation tolerates this because Hibernate accepts a database type name that prefixes the mapped type name
+(`jsonb`.startsWith(`json`)). Converting those three columns to `jsonb` is a separate POSTGRES-only migration.
 
 The SQL Server mapping is pinned explicitly by `SqlServerJsonAsVarcharTypeContributor`, registered through
 `META-INF/services/org.hibernate.boot.model.TypeContributor`. From Hibernate 7.2.19 onwards
 `AbstractTransactSQLDialect` registers the nationalized JSON descriptor, which would resolve these attributes to
 `nvarchar(max)` and fail `ddl-auto: validate` against the `varchar(max)` columns the migrations create. The
-contributor MUST be registered as a service, not via the `hibernate.type_contributors` property: property-supplied
-contributors run at `MetadataBuilder` configuration time, before dialect contributions overwrite the registration.
+contributor keys off the registered descriptor rather than the dialect: it rewrites the registration only when
+`SqlTypes.JSON` currently resolves to `JsonAsStringJdbcType.NVARCHAR_INSTANCE`, so POSTGRES and H2 — which register
+their own descriptors — are untouched. If a future Hibernate release maps SQL Server JSON to some third descriptor,
+the contributor stops applying and SQL Server startup fails schema validation loudly, by design; the SQL Server
+functional suite surfaces that in CI.
 
-Known limitation: `varchar(max)` cannot represent characters outside the column collation's code page, so non-ASCII
-content in JSON attributes is subject to lossy conversion on MS_SQL_SERVER. Removing the contributor requires
-converting all JSON columns in the `MS_SQL_SERVER` migration tree to `NVARCHAR(MAX)` in the same change.
+The contributor MUST be registered as a service, not via the `hibernate.type_contributors` property. On the JPA
+bootstrap path the service is invoked twice — once at `MetadataBuilder` configuration time, before dialect
+contributions, and once from `MetadataBuildingProcess` afterwards — and only the second invocation sees the
+nationalized descriptor. Property-supplied contributors run exclusively at the earlier point and would therefore be
+overwritten by the dialect.
+
+Known limitation: with the mssql-jdbc default `sendStringParametersAsUnicode=true`, writing characters outside the
+column collation's code page into `varchar(max)` degrades them to `?`. JSON attributes carry user-supplied text
+(env-var values, `metadata.envs[].description`), so non-ASCII content in those attributes is subject to lossy
+conversion on MS_SQL_SERVER — unlike sibling non-JSON columns such as `display_name` and `description`, which are
+`NVARCHAR(MAX)`. A UTF-8 database collation (SQL Server 2019+) removes the limitation; the functional-test fixture
+deliberately uses `SQL_Latin1_General_CP1_CS_AS` (CP1252), so the loss is reproducible. Tracked as issue #408:
+converting all JSON columns in the `MS_SQL_SERVER` migration tree to `NVARCHAR(MAX)` and dropping the contributor
+MUST happen as a single change.
 
 Status: **Implemented**
 
@@ -132,7 +150,8 @@ Status: **Implemented**
 
 #### Scenario: Other vendors keep their native JSON type
 - **WHEN** the application starts with `DATASOURCE_VENDOR=POSTGRES` or `DATASOURCE_VENDOR=H2`
-- **THEN** the contributor does not apply, and JSON attributes resolve to `jsonb` and `json` respectively
+- **THEN** the contributor does not apply, and JSON attributes resolve to the dialect's own descriptor
+  (`jsonb` and `json` respectively)
 
 ## Implementation Notes
 - Config property: `DATASOURCE_VENDOR` (`H2` | `POSTGRES` | `MS_SQL_SERVER`)

--- a/src/main/java/com/epam/aidial/deployment/manager/configuration/CLAUDE.md
+++ b/src/main/java/com/epam/aidial/deployment/manager/configuration/CLAUDE.md
@@ -31,6 +31,11 @@ When you add a new env-var-backed property here:
 
 Top-level files are individual `@Configuration` / `*Properties` classes — one concern each.
 
+One deliberate exception: `datasource/SqlServerJsonAsVarcharTypeContributor` is a Hibernate `TypeContributor`
+loaded by `ServiceLoader` (via `src/main/resources/META-INF/services/org.hibernate.boot.model.TypeContributor`),
+not a Spring bean. It lives here because it is part of the SQL Server datasource wiring — see
+`specs/database-and-migrations/spec.md` § "JSON attribute storage type is pinned per vendor".
+
 ## Related specs
 
 - `specs/api-conventions/spec.md`, `specs/security/spec.md`, `specs/observability-and-logging/spec.md` for cross-cutting concerns wired here.

--- a/src/main/java/com/epam/aidial/deployment/manager/configuration/datasource/SqlServerJsonAsVarcharTypeContributor.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/configuration/datasource/SqlServerJsonAsVarcharTypeContributor.java
@@ -3,41 +3,48 @@ package com.epam.aidial.deployment.manager.configuration.datasource;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
-import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.jdbc.JsonAsStringJdbcType;
+import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 
 /**
  * Keeps {@code @JdbcTypeCode(SqlTypes.JSON)} columns mapped to {@code varchar(max)} on SQL Server.
  *
  * <p>Hibernate 7.2.19 added {@code AbstractTransactSQLDialect#contributeTypes}, which registers
  * {@link JsonAsStringJdbcType#NVARCHAR_INSTANCE} for {@code SqlTypes.JSON}. That resolves JSON attributes to
- * {@code nvarchar(max)}, whereas our {@code MS_SQL_SERVER} Flyway migrations create those 26 columns as
+ * {@code nvarchar(max)}, whereas our {@code MS_SQL_SERVER} Flyway migrations create those columns as
  * {@code varchar(max)}. With {@code ddl-auto: validate} the mismatch fails schema validation at startup.
+ * Re-registering the non-nationalized descriptor restores the pre-7.2.19 mapping.
  *
- * <p>Re-registering the non-nationalized descriptor restores the pre-7.2.19 mapping. Dialect contributions are
- * applied before {@link TypeContributor} services (see {@code MetadataBuildingProcess}), so this registration wins.
- * Note that the {@code hibernate.type_contributors} property route would NOT work here: those contributors run at
- * {@code MetadataBuilder} configuration time, i.e. before the dialect overwrites the JSON registration.
+ * <p>The trigger is the nationalized descriptor itself, not the dialect: this contributor rewrites the registration
+ * only when {@code SqlTypes.JSON} currently resolves to {@link JsonAsStringJdbcType#NVARCHAR_INSTANCE}. POSTGRES
+ * ({@code jsonb}) and H2 (native {@code json}) register their own descriptors and are therefore untouched, and no
+ * {@code JdbcServices} lookup is needed to tell the vendors apart. If a future Hibernate release maps SQL Server
+ * JSON to some third descriptor, this contributor no longer applies and SQL Server startup fails schema validation
+ * loudly — deliberately, so the mapping is re-evaluated rather than silently pinned. The SQL Server functional
+ * suite catches that in CI.
  *
- * <p>Registered via {@code META-INF/services/org.hibernate.boot.model.TypeContributor}. Because that file is
- * global, the dialect is checked explicitly — POSTGRES ({@code jsonb}) and H2 (native {@code json}) map JSON
- * independently of nationalization and must keep the stock behaviour.
+ * <p>Registered via {@code META-INF/services/org.hibernate.boot.model.TypeContributor}, which is also why the
+ * descriptor check matters for correctness of the log line: on the JPA bootstrap path
+ * {@code EntityManagerFactoryBuilderImpl#applyTypeContributors} runs the {@link TypeContributor} services once at
+ * {@code MetadataBuilder} configuration time — before the dialect contributes — and {@code MetadataBuildingProcess}
+ * runs them again afterwards. Only the second pass sees the nationalized descriptor, so only it rewrites anything.
+ * The {@code hibernate.type_contributors} property route would never work here: property-supplied contributors run
+ * exclusively at the earlier point.
  */
 @Slf4j
 public class SqlServerJsonAsVarcharTypeContributor implements TypeContributor {
 
     @Override
     public void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
-        if (!(serviceRegistry.requireService(JdbcServices.class).getDialect() instanceof SQLServerDialect)) {
+        JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration().getJdbcTypeRegistry();
+        if (jdbcTypeRegistry.findDescriptor(SqlTypes.JSON) != JsonAsStringJdbcType.NVARCHAR_INSTANCE) {
             return;
         }
 
-        typeContributions.getTypeConfiguration()
-                .getJdbcTypeRegistry()
-                .addDescriptor(JsonAsStringJdbcType.VARCHAR_INSTANCE);
+        jdbcTypeRegistry.addDescriptor(JsonAsStringJdbcType.VARCHAR_INSTANCE);
 
-        log.info("Registered non-nationalized JSON JDBC type for SQL Server; JSON columns map to varchar(max)");
+        log.debug("Registered non-nationalized JSON JDBC type for SQL Server; JSON columns map to varchar(max)");
     }
 }

--- a/src/main/java/com/epam/aidial/deployment/manager/configuration/datasource/SqlServerJsonAsVarcharTypeContributor.java
+++ b/src/main/java/com/epam/aidial/deployment/manager/configuration/datasource/SqlServerJsonAsVarcharTypeContributor.java
@@ -1,0 +1,43 @@
+package com.epam.aidial.deployment.manager.configuration.datasource;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.boot.model.TypeContributor;
+import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.descriptor.jdbc.JsonAsStringJdbcType;
+
+/**
+ * Keeps {@code @JdbcTypeCode(SqlTypes.JSON)} columns mapped to {@code varchar(max)} on SQL Server.
+ *
+ * <p>Hibernate 7.2.19 added {@code AbstractTransactSQLDialect#contributeTypes}, which registers
+ * {@link JsonAsStringJdbcType#NVARCHAR_INSTANCE} for {@code SqlTypes.JSON}. That resolves JSON attributes to
+ * {@code nvarchar(max)}, whereas our {@code MS_SQL_SERVER} Flyway migrations create those 26 columns as
+ * {@code varchar(max)}. With {@code ddl-auto: validate} the mismatch fails schema validation at startup.
+ *
+ * <p>Re-registering the non-nationalized descriptor restores the pre-7.2.19 mapping. Dialect contributions are
+ * applied before {@link TypeContributor} services (see {@code MetadataBuildingProcess}), so this registration wins.
+ * Note that the {@code hibernate.type_contributors} property route would NOT work here: those contributors run at
+ * {@code MetadataBuilder} configuration time, i.e. before the dialect overwrites the JSON registration.
+ *
+ * <p>Registered via {@code META-INF/services/org.hibernate.boot.model.TypeContributor}. Because that file is
+ * global, the dialect is checked explicitly — POSTGRES ({@code jsonb}) and H2 (native {@code json}) map JSON
+ * independently of nationalization and must keep the stock behaviour.
+ */
+@Slf4j
+public class SqlServerJsonAsVarcharTypeContributor implements TypeContributor {
+
+    @Override
+    public void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+        if (!(serviceRegistry.requireService(JdbcServices.class).getDialect() instanceof SQLServerDialect)) {
+            return;
+        }
+
+        typeContributions.getTypeConfiguration()
+                .getJdbcTypeRegistry()
+                .addDescriptor(JsonAsStringJdbcType.VARCHAR_INSTANCE);
+
+        log.info("Registered non-nationalized JSON JDBC type for SQL Server; JSON columns map to varchar(max)");
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.TypeContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.TypeContributor
@@ -1,0 +1,1 @@
+com.epam.aidial.deployment.manager.configuration.datasource.SqlServerJsonAsVarcharTypeContributor

--- a/src/main/resources/db/migration/CLAUDE.md
+++ b/src/main/resources/db/migration/CLAUDE.md
@@ -10,6 +10,15 @@ Flyway-managed schema and data migrations, one directory per supported database 
 
 Three subdirectories: `H2/`, `POSTGRES/`, `MS_SQL_SERVER/`. New migrations MUST be added to **all three** unless the change is intentionally vendor-specific (in which case state why in the file or commit message). Mismatched versions across vendors will cause Flyway baseline drift.
 
+## Column types
+
+JSON-bearing columns (entity attributes annotated `@JdbcTypeCode(SqlTypes.JSON)`) MUST be declared as `jsonb` on
+POSTGRES, `JSON` on H2, and **`VARCHAR(MAX)` — never `NVARCHAR(MAX)`** on MS_SQL_SERVER. The SQL Server mapping is
+pinned to the non-nationalized descriptor by `SqlServerJsonAsVarcharTypeContributor`; an `NVARCHAR(MAX)` JSON column
+fails `ddl-auto: validate` at startup, and the only test that catches it is the SQL Server functional suite (part of
+`./gradlew test`, excluded from `testFast`). See `specs/database-and-migrations/spec.md` § "JSON attribute storage
+type is pinned per vendor" for the rationale and its known limitation.
+
 ## After editing
 
 - The PostToolUse hook (`.claude/hooks/generate-db-schema.sh`) regenerates `docs/db-schema.md` automatically when migration files change.


### PR DESCRIPTION
### Applicable issues

No tracked issue — routine dependency maintenance.

Related (not fixed here): #408 — the `varchar(max)` pin this PR introduces keeps a pre-existing non-ASCII
lossy-conversion limitation on SQL Server; migrating those columns to `NVARCHAR(MAX)` is tracked separately.

### Description of changes

Three things: bump `org.springframework.boot` 4.0.6 → 4.0.7, keep JSON columns mapped to `varchar(max)` on SQL
Server (fallout from the Hibernate version that bump pulls in), and raise both Jackson generations to patched
versions.

**Why 4.0.7** (constitution § Tech Stack requires a rationale for Boot upgrades): 4.0.7 is a maintenance release with
77 bug fixes plus dependency upgrades, and it carries two security fixes — CVE-2026-40992 (mail auto-configuration
SSL hostname verification) and CVE-2026-41001 (predictable temp directory in Artemis auto-configuration). Neither
affects this service directly (it auto-configures neither mail nor Artemis), so the bump is preventive: it keeps us
current on the Boot patch line rather than remediating an exposure.

**Why the SQL Server change is in the same PR:** 4.0.7 moves Hibernate ORM 7.2.12 → 7.2.19, which added
`AbstractTransactSQLDialect#contributeTypes`. That registers the *nationalized* JSON descriptor, so
`@JdbcTypeCode(SqlTypes.JSON)` attributes resolve to `nvarchar(max)` while our `MS_SQL_SERVER` migrations create
those columns as `varchar(max)` — `ddl-auto: validate` then fails at startup (this branch's first CI run failed
exactly there, in `SqlServerFunctionalTests`). `SqlServerJsonAsVarcharTypeContributor` re-registers the
non-nationalized descriptor, restoring the pre-7.2.19 mapping. It keys off the registered descriptor rather than the
dialect, so POSTGRES (`jsonb`) and H2 (`json`) are untouched. No schema or data change; behaviour on all three
vendors is identical to 4.0.6.

**Jackson — CVE-2026-59889** (`@JsonView` bypassed for `@JsonUnwrapped` container properties on deserialization,
moderate). Both generations we ship were in the vulnerable range, so both were raised:

- `tools.jackson:jackson-bom` 3.1.4 → **3.1.6**. Boot 4.0.7's BOM manages 3.1.4, which is affected
  (`>= 3.0.0, <= 3.1.4`, patched in 3.1.5), so this platform declaration is a real override again rather than the
  no-op floor it had become. 3.1.6 is the latest patch on the 3.1.x line Boot targets.
- Jackson 2 pins — `jackson-databind`, `jackson-datatype-jsr310`, `jackson-module-parameter-names` and both
  `jackson-core` constraints (buildscript + application) — 2.21.4 → **2.21.6**. The dependency-review report only
  flagged the Jackson 3 row, but the same advisory covers `>= 2.21.0, < 2.21.5`, and a second one
  (GHSA-mhm7-754m-9p8w, `@JsonView` bypass for creator properties with `@JsonUnwrapped`) covers `<= 2.21.4`. Both
  are patched in 2.21.5.

Not exploitable in this codebase — nothing under `src/` uses `@JsonView` or `@JsonUnwrapped`, and Jackson 2 is
confined to the Flyway migration mapper and Hibernate's JSON column mapping. Resolution was verified on both
`runtimeClasspath` and `testRuntimeClasspath`: every Jackson artifact now lands on 2.21.6 / 3.1.6, transitives
(`jackson-dataformat-cbor`, `-yaml`) included.

Also updated: `specs/database-and-migrations/spec.md` (new requirement documenting the per-vendor JSON storage type,
its rationale and its known `varchar` limitation), the migration-tree and `configuration/` `CLAUDE.md` files, and the
constitution (Boot pin → 4.0.7, Jackson floors → 2.21.6 / 3.1.6, version → 1.5.1 with an amendment-history row; the
PostgreSQL-driver pin was also realigned with `build.gradle`).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
